### PR TITLE
Scrobble - send episode id

### DIFF
--- a/scrobbler.py
+++ b/scrobbler.py
@@ -118,7 +118,7 @@ class Scrobbler(threading.Thread):
 		elif self.curVideo['type'] == 'episode' and scrobbleEpisodeOption == 'true':
 			match = None
 			if 'id' in self.curVideo:
-				match = utilities.getEpisodeDetailsFromXbmc(self.curVideo['id'], ['showtitle', 'season', 'episode', 'tvshowid'])
+				match = utilities.getEpisodeDetailsFromXbmc(self.curVideo['id'], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid'])
 			elif 'showtitle' in self.curVideoData and 'season' in self.curVideoData and 'episode' in self.curVideoData:
 				match = {}
 				match['tvdb_id'] = None
@@ -126,9 +126,10 @@ class Scrobbler(threading.Thread):
 				match['showtitle'] = self.curVideoData['showtitle']
 				match['season'] = self.curVideoData['season']
 				match['episode'] = self.curVideoData['episode']
+				match['uniqueid'] = self.curVideoData['uniqueid']['unknown']
 			if match == None:
 				return
-			response = utilities.watchingEpisodeOnTrakt(match['tvdb_id'], match['showtitle'], match['year'], match['season'], match['episode'], self.totalTime/60, int(100*self.watchedTime/self.totalTime))
+			response = utilities.watchingEpisodeOnTrakt(match['tvdb_id'], match['showtitle'], match['year'], match['season'], match['episode'], match['uniqueid']['unknown'], self.totalTime/60, int(100*self.watchedTime/self.totalTime))
 			if response != None:
 				Debug("[Scrobbler] Watch response: "+str(response))
 
@@ -166,7 +167,7 @@ class Scrobbler(threading.Thread):
 		elif self.curVideo['type'] == 'episode' and scrobbleEpisodeOption == 'true':
 			match = None
 			if 'id' in self.curVideo:
-				match = utilities.getEpisodeDetailsFromXbmc(self.curVideo['id'], ['showtitle', 'season', 'episode', 'tvshowid'])
+				match = utilities.getEpisodeDetailsFromXbmc(self.curVideo['id'], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid'])
 			elif 'showtitle' in self.curVideoData and 'season' in self.curVideoData and 'episode' in self.curVideoData:
 				match = {}
 				match['tvdb_id'] = None
@@ -174,9 +175,10 @@ class Scrobbler(threading.Thread):
 				match['showtitle'] = self.curVideoData['showtitle']
 				match['season'] = self.curVideoData['season']
 				match['episode'] = self.curVideoData['episode']
+				match['uniqueid'] = self.curVideoData['uniqueid']['unknown']
 			if match == None:
 				return
-			response = utilities.scrobbleEpisodeOnTrakt(match['tvdb_id'], match['showtitle'], match['year'], match['season'], match['episode'], self.totalTime/60, int(100*self.watchedTime/self.totalTime))
+			response = utilities.scrobbleEpisodeOnTrakt(match['tvdb_id'], match['showtitle'], match['year'], match['season'], match['episode'], match['uniqueid']['unknown'], self.totalTime/60, int(100*self.watchedTime/self.totalTime))
 			if response != None:
 				Debug("[Scrobbler] Scrobble response: "+str(response))
 

--- a/utilities.py
+++ b/utilities.py
@@ -275,8 +275,8 @@ def watchingMovieOnTrakt(imdb_id, title, year, duration, percent):
 	return response
 
 #tell trakt that the user is watching an episode
-def watchingEpisodeOnTrakt(tvdb_id, title, year, season, episode, duration, percent):
-	response = traktJsonRequest('POST', '/show/watching/%%API_KEY%%', {'tvdb_id': tvdb_id, 'title': title, 'year': year, 'season': season, 'episode': episode, 'duration': math.ceil(duration), 'progress': math.ceil(percent)}, passVersions=True)
+def watchingEpisodeOnTrakt(tvdb_id, title, year, season, episode, uniqueid, duration, percent):
+	response = traktJsonRequest('POST', '/show/watching/%%API_KEY%%', {'tvdb_id': tvdb_id, 'title': title, 'year': year, 'season': season, 'episode': episode, 'episode_tvdb_id': uniqueid, 'duration': math.ceil(duration), 'progress': math.ceil(percent)}, passVersions=True)
 	if response == None:
 		Debug("Error in request from 'watchingEpisodeOnTrakt()'")
 	return response
@@ -303,8 +303,8 @@ def scrobbleMovieOnTrakt(imdb_id, title, year, duration, percent):
 	return response
 
 #tell trakt that the user has finished watching an episode
-def scrobbleEpisodeOnTrakt(tvdb_id, title, year, season, episode, duration, percent):
-	response = traktJsonRequest('POST', '/show/scrobble/%%API_KEY%%', {'tvdb_id': tvdb_id, 'title': title, 'year': year, 'season': season, 'episode': episode, 'duration': math.ceil(duration), 'progress': math.ceil(percent)}, passVersions=True)
+def scrobbleEpisodeOnTrakt(tvdb_id, title, year, season, episode, uniqueid, duration, percent):
+	response = traktJsonRequest('POST', '/show/scrobble/%%API_KEY%%', {'tvdb_id': tvdb_id, 'title': title, 'year': year, 'season': season, 'episode': episode, 'episode_tvdb_id': uniqueid, 'duration': math.ceil(duration), 'progress': math.ceil(percent)}, passVersions=True)
 	if response == None:
 		Debug("Error in request from 'scrobbleEpisodeOnTrakt()'")
 	return response


### PR DESCRIPTION
This will send the episode id (titled "unknown" but assumed to be TVDB) thus enabling support for absolute and dvd ordering.

The function went into Frodo just before feature freeze, any episodes scraped before then will need a refresh to capture the episode id.

This concludes the great quest to support my anime which has only taken about a year :)
