### PR TITLE
Compare watched trakt media against only watched xbmc media

### DIFF
--- a/episode_sync.py
+++ b/episode_sync.py
@@ -146,7 +146,8 @@ class SyncEpisodes():
 
 			if missing:
 				show = {'title': xbmc_show['title'], 'episodes': [{'episode': x['episode'], 'season': x['season'], 'episode_tvdb_id': x['uniqueid']['unknown']} for x in missing]}
-					
+				Debug('[Episodes Sync][AddToTrakt] %s' % show)
+
 				if xbmc_show['imdbnumber'].isdigit():
 					show['tvdb_id'] = xbmc_show['imdbnumber']
 				else:
@@ -176,7 +177,7 @@ class SyncEpisodes():
 		self.trakt_shows['watched'] = traktJsonRequest('POST', '/user/library/shows/watched.json/%%API_KEY%%/%%USERNAME%%/min')
 
 	def UpdatePlaysTrakt(self):
-		Debug('[Episodes Sync] Cecking watched episodes on trakt.tv')
+		Debug('[Episodes Sync] Checking watched episodes on trakt.tv')
 		if self.show_progress:
 			progress.update(70, line1=__getstring__(1438), line2=' ', line3=' ')
 
@@ -194,8 +195,15 @@ class SyncEpisodes():
 
 			trakt_title_index[self.trakt_shows['watched'][i]['title']] = i
 
-		for xbmc_show in self.xbmc_shows:
+		xbmc_shows_watched = []
+		for show in self.xbmc_shows:
+			watched_episodes = [x for x in show['episodes'] if x['playcount']]
+			if watched_episodes:
+				xbmc_shows_watched.append(show)
+
+		for xbmc_show in xbmc_shows_watched:
 			missing = []
+			trakt_show = {}
 
 			#IMDB ID
 			if xbmc_show['imdbnumber'].startswith('tt') and xbmc_show['imdbnumber'] in trakt_imdb_index.keys():
@@ -213,12 +221,12 @@ class SyncEpisodes():
 			if trakt_show:
 				missing = compare_show_watched_trakt(xbmc_show, trakt_show)
 			else:
-				Debug('[Episodes Sync] Failed to find %s on trakt.tv' % xbmc_show['title'])
-
+				missing = [x for x in xbmc_show['episodes'] if x['playcount']]
 
 			if missing:
 				show = {'title': xbmc_show['title'], 'episodes': [{'episode': x['episode'], 'season': x['season'], 'episode_tvdb_id': x['uniqueid']['unknown']} for x in missing]}
-					
+				Debug('[Episodes Sync][UpdatePlaysTrakt] %s' % show)
+
 				if xbmc_show['imdbnumber'].isdigit():
 					show['tvdb_id'] = xbmc_show['imdbnumber']
 				else:

--- a/movie_sync.py
+++ b/movie_sync.py
@@ -81,18 +81,20 @@ class SyncMovies():
 			#Compare IMDB IDs
 			if xbmc_movie['imdbnumber'].startswith('tt'):
 				if xbmc_movie['imdbnumber'] not in trakt_imdb_ids:
+					Debug('[Movies Sync][AddToTrakt] %s' % xbmc_movie)
 					add_to_trakt.append(xbmc_movie)
 
 			#Compare TMDB IDs
 			elif xbmc_movie['imdbnumber'].isdigit():
 				if xbmc_movie['imdbnumber'] not in trakt_tmdb_ids:
+					Debug('[Movies Sync][AddToTrakt] %s' % xbmc_movie)
 					add_to_trakt.append(xbmc_movie)
 
 			#Compare titles if unknown ID type
 			else:
 				if xbmc_movie['title'] not in trakt_titles:
+					Debug('[Movies Sync][AddToTrakt] %s' % xbmc_movie)
 					add_to_trakt.append(xbmc_movie)
-
 
 		if add_to_trakt:
 			Debug('[Movies Sync] %i movie(s) will be added to trakt.tv collection' % len(add_to_trakt))
@@ -112,6 +114,7 @@ class SyncMovies():
 
 		update_playcount = []
 		trakt_playcounts = {}
+		xbmc_movies_seen = [x for x in self.xbmc_movies if x['playcount']]
 
 		for trakt_movie in self.trakt_movies_seen:
 			if 'tmdb_id' in trakt_movie:
@@ -122,15 +125,24 @@ class SyncMovies():
 
 			trakt_playcounts[trakt_movie['title']] = trakt_movie['plays']
 
-		for xbmc_movie in self.xbmc_movies:
+		for xbmc_movie in xbmc_movies_seen:
 			if xbmc_movie['imdbnumber'] in trakt_playcounts:
 				if trakt_playcounts[xbmc_movie['imdbnumber']] < xbmc_movie['playcount']:
+					Debug('[Movies Sync][UpdatePlaysTrakt] %s' % xbmc_movie)
 					update_playcount.append(xbmc_movie)
+				else:
+					pass
 
 			elif xbmc_movie['title'] in trakt_playcounts:
 				if trakt_playcounts[xbmc_movie['title']] < xbmc_movie['playcount']:
+					Debug('[Movies Sync][UpdatePlaysTrakt][Update] %s' % xbmc_movie)
 					update_playcount.append(xbmc_movie)
+				else:
+					pass
 
+			else:
+				Debug('[Movies Sync][UpdatePlaysTrakt][Update] %s' % xbmc_movie)
+				update_playcount.append(xbmc_movie)
 
 		if update_playcount:
 			Debug('[Movies Sync] %i movie(s) playcount will be updated on trakt.tv' % len(update_playcount))


### PR DESCRIPTION
This started as a hunt for rouge movies that would always be marked as missing on trakt.
I found a couple reasons as to why this would happen. The first is the xbmc movie has wrong metadata. The second is trakt is missing metadata.
The only solution i found was to fix my broken metadata or fix trakts metadata (VIP force refresh, the imdb_id was missing). Both worked.

I added better debug logging to help identify these cases.
When the better debugging was enabled i noticed i was getting a heap of false non-matches for updating playcount. There was an error in the logic which this should fix.
