### PR TITLE
Episode Sync playcount for unwatched shows bug

### DIFF
--- a/episode_sync.py
+++ b/episode_sync.py
@@ -269,6 +269,7 @@ class SyncEpisodes():
 
 		for xbmc_show in self.xbmc_shows:
 			missing = []
+			trakt_show = None
 
 			#IMDB ID
 			if xbmc_show['imdbnumber'].startswith('tt') and xbmc_show['imdbnumber'] in trakt_imdb_index.keys():


### PR DESCRIPTION
Reset trakt_show variable to None during XBMC playcount syncing with trakt.tv

Without this, when the addon finds a show which has no watched episodes on trakt,
it defaults to using the previous shows "watched" list, instead of not updating anything
