### PR TITLE
Fixed episode sync not picking up missing trakt.tv playcounts on new season

### DIFF
--- a/episode_sync.py
+++ b/episode_sync.py
@@ -37,10 +37,13 @@ def compare_show_watched_trakt(xbmc_show, trakt_show):
 
 	for xbmc_episode in xbmc_show['episodes']:
 		if xbmc_episode['playcount']:
-			for trakt_season in trakt_show['seasons']:
-				if xbmc_episode['season'] == trakt_season['season']:
-					if xbmc_episode['episode'] not in trakt_season['episodes']:
-						missing.append(xbmc_episode)
+			if xbmc_episode['season'] not in [x['season'] for x in trakt_show['seasons']]:
+				missing.append(xbmc_episode)
+			else:
+				for trakt_season in trakt_show['seasons']:
+					if xbmc_episode['season'] == trakt_season['season']:
+						if xbmc_episode['episode'] not in trakt_season['episodes']:
+							missing.append(xbmc_episode)
 
 	return missing
 


### PR DESCRIPTION
Fixed episode sync not picking up missing trakt.tv playcounts on new season.

For instance, if you have watched 4 seasons of Alias, and then watch episode 5x1, it won't pick up that it's missing on trakt.tv
