### PR TITLE
Readtimeout handling

### DIFF
--- a/nbconnection.py
+++ b/nbconnection.py
@@ -20,6 +20,7 @@ class NBConnection():
 		self.response = None
 		self.responseLock = threading.Lock()
 		self.closing = False
+		self.readError = False
 
 	def request(self, method, url, body=None, headers={}):
 		self.rawConnection.request(method, url, body, headers)
@@ -41,7 +42,15 @@ class NBConnection():
 		thread.start_new_thread(NBConnection._run, (self,))
 
 	def _run(self):
-		self.response = self.rawConnection.getresponse()
+		print "[trakt] [nbconnection] getresponse start"
+		try:
+			self.response = self.rawConnection.getresponse()
+		except:
+			print "[trakt] [nbconnection] Exception"
+			self.readError = True
+			self.close()
+		else:
+			print "[trakt] [nbconnection] response received: " + str(self.response.status) + " " + self.response.reason
 		self.responseLock.release()
 
 	def close(self):

--- a/utilities.py
+++ b/utilities.py
@@ -153,14 +153,23 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 
 	while True:
 		if xbmc.abortRequested:
-			Debug("Broke loop due to abort")
+			Debug("traktJsonRequest(): Broke loop due to abort")
 			if returnStatus:
 				data = {}
 				data['status'] = 'failure'
 				data['error'] = 'Abort requested, not waiting for response'
 				return data
 			return None
+		if conn.readError:
+			Debug("traktJsonRequest(): Error getting reading response")
+			if returnStatus:
+				data = {}
+				data['status'] = 'failure'
+				data['error'] = 'Error getting response, read error on socket.'
+				return data
+			return None
 		if conn.hasResult():
+			Debug("traktJsonRequest(): hasResult()")
 			break
 		time.sleep(0.1)
 

--- a/utilities.py
+++ b/utilities.py
@@ -161,7 +161,7 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 				return data
 			return None
 		if conn.readError:
-			Debug("traktJsonRequest(): Error getting reading response")
+			Debug("traktJsonRequest(): Error reading response")
 			if returnStatus:
 				data = {}
 				data['status'] = 'failure'
@@ -173,8 +173,29 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 			break
 		time.sleep(0.1)
 
+	Debug("traktJsonRequest(): Get response object")
 	response = conn.getResult()
-	raw = response.read()
+	if response = None:
+		Debug("traktJsonRequest(): Response not set")
+		if returnStatus:
+			data = {}
+			data['status'] = 'failure'
+			data['error'] = 'Error getting response, response not set.'
+			return data
+		return None
+		
+	Debug("traktJsonRequest(): Trying to read response")
+	try:
+		raw = response.read()
+	except:
+		Debug("traktJsonRequest(): Exception reading response")
+		if returnStatus:
+			data = {}
+			data['status'] = 'failure'
+			data['error'] = 'Error getting response, exception reading response.'
+			return data
+		return None
+	
 	if closeConnection:
 		conn.close()
 

--- a/utilities.py
+++ b/utilities.py
@@ -177,7 +177,7 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 
 	Debug("traktJsonRequest(): Get response object.")
 	response = conn.getResult()
-	if response = None:
+	if response == None:
 		Debug("traktJsonRequest(): Response not set.")
 		if returnStatus:
 			data = {}

--- a/utilities.py
+++ b/utilities.py
@@ -113,6 +113,7 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 		conn = getTraktConnection()
 		closeConnection = True
 	if conn == None:
+		Debug("traktJsonRequest(): Unable to create connection to trakt.")
 		if returnStatus:
 			data = {}
 			data['status'] = 'failure'
@@ -136,10 +137,11 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 		elif method == 'GET':
 			conn.request('GET', req)
 		else:
+			Debug("traktJsonRequest(): Unknown method " + method)
 			return None
-		Debug("json url: "+req)
+		Debug("traktJsonRequest(): "+method+" JSON url: "+req)
 	except socket.error:
-		Debug("traktQuery: can't connect to trakt")
+		Debug("traktJsonRequest(): Unable to connect to trakt.")
 		if not silent:
 			notification("trakt", __language__(1108).encode( "utf-8", "ignore" )) # can't connect to trakt
 		if returnStatus:
@@ -153,7 +155,7 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 
 	while True:
 		if xbmc.abortRequested:
-			Debug("traktJsonRequest(): Broke loop due to abort")
+			Debug("traktJsonRequest(): Broke loop due to abort.")
 			if returnStatus:
 				data = {}
 				data['status'] = 'failure'
@@ -161,7 +163,7 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 				return data
 			return None
 		if conn.readError:
-			Debug("traktJsonRequest(): Error reading response")
+			Debug("traktJsonRequest(): Error reading response.")
 			if returnStatus:
 				data = {}
 				data['status'] = 'failure'
@@ -173,10 +175,10 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 			break
 		time.sleep(0.1)
 
-	Debug("traktJsonRequest(): Get response object")
+	Debug("traktJsonRequest(): Get response object.")
 	response = conn.getResult()
 	if response = None:
-		Debug("traktJsonRequest(): Response not set")
+		Debug("traktJsonRequest(): Response not set.")
 		if returnStatus:
 			data = {}
 			data['status'] = 'failure'
@@ -184,11 +186,11 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 			return data
 		return None
 		
-	Debug("traktJsonRequest(): Trying to read response")
+	Debug("traktJsonRequest(): Trying to read response.")
 	try:
 		raw = response.read()
 	except:
-		Debug("traktJsonRequest(): Exception reading response")
+		Debug("traktJsonRequest(): Exception reading response.")
 		if returnStatus:
 			data = {}
 			data['status'] = 'failure'
@@ -201,8 +203,9 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 
 	try:
 		data = json.loads(raw)
+		Debug("traktJsonRequest(): JSON response: " + str(data))
 	except ValueError:
-		Debug("traktQuery: Bad JSON response: "+raw)
+		Debug("traktJsonRequest(): Bad JSON response: " + raw)
 		if returnStatus:
 			data = {}
 			data['status'] = 'failure'
@@ -214,7 +217,7 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 
 	if 'status' in data:
 		if data['status'] == 'failure':
-			Debug("traktQuery: Error: " + str(data['error']))
+			Debug("traktJsonRequest(): Error: " + str(data['error']))
 			if returnStatus:
 				return data
 			if not silent:


### PR DESCRIPTION
Attempt to fix read timeouts causing crashes.

Happens during nbconnection._run thread, Read operation timed out.  Have seen this traceback in my log a couple times, its rare but does happen.  When it does, it'll cause the current json request loop to run indefinetly, or until xbmc is closed.

Also added a bit more error handling and cleaned up some error messages in traktJsonRequest.
