### PR TITLE
Notification rewrite

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -1,102 +1,166 @@
 # -*- coding: utf-8 -*-
 """ Handles notifications from XBMC via its own thread and forwards them on to the scrobbler """
 
+import sys
 import xbmc
-import telnetlib
-import socket
-import time
+import xbmcaddon
+import xbmcgui
 
-import simplejson as json
+if sys.version_info < (2, 7):
+	import simplejson as json
+else:
+	import json
 
-import threading
 from utilities import Debug
 from scrobbler import Scrobbler
 from movie_sync import SyncMovies
 from episode_sync import SyncEpisodes
 from sync_exec import do_sync
 
-class NotificationService(threading.Thread):
-	""" Receives XBMC notifications and passes them off as needed """
+class NotificationService:
 
-	TELNET_ADDRESS = 'localhost'
-	TELNET_PORT = 9090
-
-	_abortRequested = False
 	_scrobbler = None
-	_notificationBuffer = ""
+	
+	def __init__(self):
+		self.run()
 
-
-	def _forward(self, notification):
-		""" Fowards the notification recieved to a function on the scrobbler """
-		if not ('method' in notification and 'params' in notification and 'sender' in notification['params'] and notification['params']['sender'] == 'xbmc'):
-			return
-
-		if notification['method'] == 'Player.OnStop':
+	def _dispatch(self, data):
+		Debug("[Notification] Dispatch: %s" % data)
+		xbmc.sleep(500)
+		action = data["action"]
+		if action == "started":
+			p = {"item": {"type": data["type"], "id": data["id"]}}
+			self._scrobbler.playbackStarted(p)
+		elif action == "ended" or action == "stopped":
 			self._scrobbler.playbackEnded()
-		elif notification['method'] == 'Player.OnPlay':
-			if 'data' in notification['params'] and 'item' in notification['params']['data'] and 'type' in notification['params']['data']['item']:
-				self._scrobbler.playbackStarted(notification['params']['data'])
-		elif notification['method'] == 'Player.OnPause':
+		elif action == "paused":
 			self._scrobbler.playbackPaused()
-		elif notification['method'] == 'VideoLibrary.OnScanFinished':
+		elif action == "resumed":
+			self._scrobbler.playbackResumed()
+		elif action == "databaseUpdated":
 			if do_sync('movies'):
 				movies = SyncMovies(show_progress=False)
 				movies.Run()
 			if do_sync('episodes'):
 				episodes = SyncEpisodes(show_progress=False)
 				episodes.Run()
-		elif notification['method'] == 'System.OnQuit':
-			self._abortRequested = True
-
-
-	def _readNotification(self, telnet):
-		""" Read a notification from the telnet connection, blocks until the data is available, or else raises an EOFError if the connection is lost """
-		while True:
-			try:
-				addbuffer = telnet.read_some()
-			except socket.timeout:
-				continue
-
-			if addbuffer == "":
-				raise EOFError
-
-			self._notificationBuffer += addbuffer
-			try:
-				data, offset = json.JSONDecoder().raw_decode(self._notificationBuffer)
-				self._notificationBuffer = self._notificationBuffer[offset:]
-			except ValueError:
-				continue
-
-			return data
-
+		elif action == "scanStarted":
+			Debug("[Notification] Dispatch: scanStarted")
+		else:
+			Debug("[Notification] '%s' unknown dispatch action!" % action)
 
 	def run(self):
-		#while xbmc is running
+		Debug("[Notification] Starting")
+		
+		# setup event driven classes
+		self.Player = traktPlayer(action = self._dispatch)
+		self.Monitor = traktMonitor(action = self._dispatch)
+		
+		# initalize scrobbler class
 		self._scrobbler = Scrobbler()
 		self._scrobbler.start()
-		while not (self._abortRequested or xbmc.abortRequested):
-			try:
-				#try to connect, catch errors and retry every 5 seconds
-				telnet = telnetlib.Telnet(self.TELNET_ADDRESS, self.TELNET_PORT)
-				
-				#if connection succeeds
-				while not (self._abortRequested or xbmc.abortRequested):
-					try:
-						#read notification data
-						data = self._readNotification(telnet)
-						Debug("[Notification Service] message: " + str(data))
-						self._forward(data)
-					except EOFError:
-						#if we end up here, it means the connection was lost or reset,
-						# so we empty out the buffer, and exit this loop, which retries
-						# the connection in the outer loop
-						self._notificationBuffer = ""
-						break
-			except:
-				time.sleep(5)
-				continue
+		
+		# start loop for events
+		while (not xbmc.abortRequested):
+			xbmc.sleep(500)
+			
+		# we aborted
+		if xbmc.abortRequested:
+			Debug("[Notification] abortRequested received, shutting down.")
+			# join scrobbler, to wait for termination
+			Debug("[Notification] Joining scrobbler thread to wait for exit.")
+			self._scrobbler.join()
 
+class traktMonitor(xbmc.Monitor):
 
-		telnet.close()
-		self._scrobbler.abortRequested = True
-		Debug("Notification service stopping")
+	def __init__(self, *args, **kwargs):
+		xbmc.Monitor.__init__(self)
+		self.action = kwargs["action"]
+		Debug("[traktMonitor] Initalized")
+
+	# called when database gets updated and return video or music to indicate which DB has been changed
+	def onDatabaseUpdated(self, database):
+		Debug("[traktMonitor] onDatabaseUpdated(database: %s)" % database)
+		# equivalent to a VideoLibrary.OnScanFinished
+		data = {"action": "databaseUpdated"}
+		self.action(data)
+
+	# called when database update starts and return video or music to indicate which DB is being updated
+	def onDatabaseScanStarted(self, database):
+		Debug("[traktMonitor] onDatabaseScanStarted(database: %s)" % database)
+		data = {"action": "scanStarted"}
+		self.action(data)
+
+class traktPlayer(xbmc.Player):
+
+	def __init__(self, *args, **kwargs):
+		xbmc.Player.__init__(self)
+		self.action = kwargs["action"]
+		Debug("[traktPlayer] Initalized")
+
+	# called when xbmc starts playing a file
+	def onPlayBackStarted(self):
+		xbmc.sleep(1000)
+		self.type = None
+		self.id = None
+		
+		# only do anything if we're playing a video
+		if self.isPlayingVideo():
+			# get item data from json rpc
+			rpccmd = json.dumps({"jsonrpc": "2.0", "method": "Player.GetItem", "params": {"playerid": 1}, "id": 1})
+			result = xbmc.executeJSONRPC(rpccmd)
+			Debug("[traktPlayer] onPlayBackStarted() - %s" % result)
+			result = json.loads(result)
+			
+			self.type = result["result"]["item"]["type"]
+			self.id = result["result"]["item"]["id"]
+			
+			data = {"action": "started", "id": self.id, "type": self.type}
+			
+			# send dispatch
+			self.action(data)
+
+	# called when xbmc stops playing a file
+	def onPlayBackEnded(self):
+		Debug("[traktPlayer] onPlayBackEnded() - %s" % self.isPlayingVideo())
+		data = {"action": "ended"}
+		self.action(data)
+
+	# called when user stops xbmc playing a file
+	def onPlayBackStopped(self):
+		Debug("[traktPlayer] onPlayBackStopped() - %s" % self.isPlayingVideo())
+		data = {"action": "stopped"}
+		self.action(data)
+
+	# called when user pauses a playing file
+	def onPlayBackPaused(self):
+		if self.isPlayingVideo():
+			Debug("[traktPlayer] onPlayBackPaused() - %s" % self.isPlayingVideo())
+			data = {"action": "paused"}
+			self.action(data)
+
+	# called when user resumes a paused file
+	def onPlayBackResumed(self):
+		if self.isPlayingVideo():
+			Debug("[traktPlayer] onPlayBackResumed() - %s" % self.isPlayingVideo())
+			data = {"action": "resumed"}
+			self.action(data)
+
+	# called when user queues the next item
+	def onQueueNextItem(self):
+		Debug("[traktPlayer] onQueueNextItem() - %s" % self.isPlayingVideo())
+
+	# called when players speed changes. (eg. user FF/RW)
+	def onPlayBackSpeedChanged(self, speed):
+		if self.isPlayingVideo():
+			Debug("[traktPlayer] onPlayBackSpeedChanged(speed: %s) - %s" % (str(speed), self.isPlayingVideo()))
+
+	# called when user seeks to a time
+	def onPlayBackSeek(self, time, offset):
+		if self.isPlayingVideo():
+			Debug("[traktPlayer] onPlayBackSeek(time: %s, offset: %s) - %s" % (str(time), str(offset), self.isPlayingVideo()))
+
+	# called when user performs a chapter seek
+	def onPlayBackSeekChapter(self, chapter):
+		if self.isPlayingVideo():
+			Debug("[traktPlayer] onPlayBackSeekChapter(chapter: %s) - %s" % (str(chapter), self.isPlayingVideo()))

--- a/notification_service.py
+++ b/notification_service.py
@@ -80,16 +80,17 @@ class traktMonitor(xbmc.Monitor):
 
 	# called when database gets updated and return video or music to indicate which DB has been changed
 	def onDatabaseUpdated(self, database):
-		Debug("[traktMonitor] onDatabaseUpdated(database: %s)" % database)
-		# equivalent to a VideoLibrary.OnScanFinished
-		data = {"action": "databaseUpdated"}
-		self.action(data)
+		if database == "video":
+			Debug("[traktMonitor] onDatabaseUpdated(database: %s)" % database)
+			data = {"action": "databaseUpdated"}
+			self.action(data)
 
 	# called when database update starts and return video or music to indicate which DB is being updated
 	def onDatabaseScanStarted(self, database):
-		Debug("[traktMonitor] onDatabaseScanStarted(database: %s)" % database)
-		data = {"action": "scanStarted"}
-		self.action(data)
+		if database == "video":
+			Debug("[traktMonitor] onDatabaseScanStarted(database: %s)" % database)
+			data = {"action": "scanStarted"}
+			self.action(data)
 
 class traktPlayer(xbmc.Player):
 

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -32,6 +32,7 @@ class Scrobbler(threading.Thread):
 			if self.pinging and xbmc.Player().isPlayingVideo():
 				count += 1
 				self.watchedTime = xbmc.Player().getTime()
+				self.startTime = time.time()
 				if count >= 100:
 					self.startedWatching()
 					count = 0

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -28,8 +28,8 @@ class Scrobbler(threading.Thread):
 		# When requested ping trakt to say that the user is still watching the item
 		count = 0
 		while (not (self.abortRequested or xbmc.abortRequested)):
-			time.sleep(5)
-			if self.pinging:
+			xbmc.sleep(5000) # sleep for 5 seconds
+			if self.pinging and xbmc.Player().isPlayingVideo():
 				count += 1
 				self.watchedTime = xbmc.Player().getTime()
 				if count >= 100:

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -80,6 +80,13 @@ class Scrobbler(threading.Thread):
 				self.curVideo = None
 				self.startTime = 0
 
+	def playbackResumed(self):
+		if self.pausedTime != 0:
+			p = time.time() - self.pausedTime
+			Debug("[Scrobbler] Resumed after: %s" % str(p))
+			self.pausedTime = 0
+			self.startedWatching()
+	
 	def playbackPaused(self):
 		if self.startTime != 0:
 			self.watchedTime += time.time() - self.startTime

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -62,7 +62,9 @@ class Scrobbler(threading.Thread):
 							self.totalTime = 30
 						else:
 							self.totalTime = 1
-					self.playlistLength = utilities.getPlaylistLengthFromXBMCPlayer(data['player']['playerid'])
+					#self.playlistLength = utilities.getPlaylistLengthFromXBMCPlayer(data['player']['playerid'])
+					# playerid 1 is video.
+					self.playlistLength = utilities.getPlaylistLengthFromXBMCPlayer(1)
 					if (self.playlistLength == 0):
 						Debug("[Scrobbler] Warning: Cant find playlist length?!, assuming that this item is by itself")
 						self.playlistLength = 1

--- a/service.py
+++ b/service.py
@@ -6,15 +6,18 @@ from utilities import Debug, checkSettings
 from notification_service import NotificationService
 
 __settings__ = xbmcaddon.Addon("script.trakt")
-__language__ = __settings__.getLocalizedString
+__addonversion__ = __addon__.getAddonInfo('version')
+__addonid__ = __addon__.getAddonInfo('id')
+__language__ = __addon__.getLocalizedString
 
-Debug("loading " + __settings__.getAddonInfo("id") + " version " + __settings__.getAddonInfo("version"))
+Debug("Loading '%s' version '%s'" % (__addonid__, __addonversion__))
 
 # starts update/sync
 def autostart():
 	if checkSettings(True):
-		notificationThread = NotificationService()
-		notificationThread.start()
-		notificationThread.join()
+		# startup notifcation service
+		NotificationService()
+	
+	Debug("Plugin shutting down.")
 
 autostart()

--- a/utilities.py
+++ b/utilities.py
@@ -88,21 +88,15 @@ def chunks(l, n):
 
 # helper method to format api call url
 def formatTraktURL(req):
-	https = __settings__.getSetting('https')
-	
-	result = "http"
-	
-	if https:
-		result = result + "s"
 
-	result = result + "://api.trakt.tv"
+	# default to always https
+	url = "https://api.trakt.tv" + req
 	
-	req = req.replace("%%API_KEY%%", apikey)
-	req = req.replace("%%USERNAME%%", username)
+	# replace api and username values
+	url = url.replace("%%API_KEY%%", apikey)
+	url = url.replace("%%USERNAME%%", username)
 	
-	result = result + req
-	
-	return result
+	return url
 
 # helper function for making requests through urllib2
 def get_data(url, args):

--- a/utilities.py
+++ b/utilities.py
@@ -17,11 +17,6 @@ try:
 except ImportError:
 	import json
 
-try:
-	from hashlib import sha as sha # Python 2.6 +
-except ImportError:
-	import sha # Python 2.5 and earlier
-
 # read settings
 __settings__ = xbmcaddon.Addon("script.trakt")
 __language__ = __settings__.getLocalizedString


### PR DESCRIPTION
Rewrite of the notification service to use the python event driven methods, as opposed to needing to connect to telnet and retrying connection is this is lost.

I've also changed to solely use https, just didn't remove the option to toggle https yet.

Also, 2 fixes in scrobbler.

Debug logging at the moment for this is fairly verbose, so I can see what being triggered when while testing.  Will be giving a full test run when tonight.

Overall, needs testing, and feedback from others please.
