### PR TITLE
Rename __setting__ to __addon__

### DIFF
--- a/service.py
+++ b/service.py
@@ -5,7 +5,7 @@ import xbmcaddon
 from utilities import Debug, checkSettings, getTraktSettings
 from notification_service import NotificationService
 
-__settings__ = xbmcaddon.Addon("script.trakt")
+__addon__ = xbmcaddon.Addon("script.trakt")
 __addonversion__ = __addon__.getAddonInfo('version')
 __addonid__ = __addon__.getAddonInfo('id')
 __language__ = __addon__.getLocalizedString


### PR DESCRIPTION
Forgot to rename **setting** variable to **addon**

Can't believe i missed this in the initial pull request, don't i feel like an idiot now :(
