### PR TITLE
Some fixes

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -11,7 +11,7 @@ if sys.version_info < (2, 7):
 else:
 	import json
 
-from utilities import Debug
+from utilities import Debug, checkScrobblingExclusion
 from scrobbler import Scrobbler
 from movie_sync import SyncMovies
 from episode_sync import SyncEpisodes
@@ -116,8 +116,16 @@ class traktPlayer(xbmc.Player):
 			result = json.loads(result)
 			
 			self.type = result["result"]["item"]["type"]
+			
+			# check for non-library item playback
 			if self.type == "unknown":
 				Debug("[traktPlayer] onPlayBackStarted() - Started playing a non-library file, skipping.")
+				return
+			
+			# check for exclusion
+			_filename = self.getPlayingFile()
+			if checkScrobblingExclusion(_filename):
+				Debug("[traktPlayer] onPlayBackStarted() - '%s' is in exclusion settings, ignoring." % _filename)
 				return
 			
 			self.id = result["result"]["item"]["id"]

--- a/resources/language/Dutch/string.xml
+++ b/resources/language/Dutch/string.xml
@@ -6,7 +6,6 @@
 	<string id="1012">API Key (te vinden op trakt -&gt; Settings -&gt; API)</string>
 	<string id="1013">Gebruikersnaam</string>
 	<string id="1014">Wachtwoord</string>
-    <string id="1016">Use secure connection (HTTPS)</string>
 	
 	<string id="1020">Automatisch synchroniseren</string>
 	<string id="1021">Automatisch bijwerken Film Collectie bij opstarten</string>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -6,7 +6,6 @@
 	<string id="1012">API Key (optional)</string>
 	<string id="1013">Username</string>
 	<string id="1014">Password</string>
-	<string id="1016">Use secure connection (HTTPS)</string>
 	<string id="1017">Number of Retries</string>
 	
 	<string id="1020">Auto Syncing</string>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -5,7 +5,6 @@
 	<string id="1002">API Key</string>
 	<string id="1003">Benutzername</string>
 	<string id="1004">Passwort</string>
-	<string id="1016">Sichere Verbindung benutzen (HTTPS)</string>
 	<string id="1005">Aktualisiere Filmsammlung beim start</string>
 	<string id="1006">Aktualisiere Seriensammlung beim start</string>
 	<string id="1007">Synchronisiere gesehene Filme beim start</string>

--- a/resources/language/Polish/strings.xml
+++ b/resources/language/Polish/strings.xml
@@ -10,7 +10,6 @@
 	<string id="1012">Klucz API (dostępny na trakt --&gt; Ustawienia --&gt; API)</string>
 	<string id="1013">Użytkownik</string>
 	<string id="1014">Hasło</string>
-	<string id="1016">Use secure connection (HTTPS)</string>
 	<string id="1020">Auto synchronizacja</string>
 	<string id="1021">Auto aktualizacja Kolekcji Filmów przy starcie</string>
 	<string id="1022">Auto aktualizacja Kolekcji Seriali przy starcie</string>

--- a/resources/language/Portuguese (Brazil)/strings.xml
+++ b/resources/language/Portuguese (Brazil)/strings.xml
@@ -6,7 +6,6 @@
 	<string id="1012">Chave API (encontre em trakt --&gt; Settings --&gt; API)</string>
 	<string id="1013">Usuário</string>
 	<string id="1014">Senha</string>
-	<string id="1016">Usar conexão segura (HTTPS)</string>
 	
 	<string id="1020">Auto Sincronia</string>
 	<string id="1021">Auto atualizar Coleção de Filmes ao iniciar</string>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,7 +4,6 @@
 		<setting id="username" type="text" label="1013" default="" />
 		<setting id="password" type="text" option="hidden" label="1014" default="" />
 		<setting id="debug" type="bool" label="1011" default="true"/>
-		<setting id="https" type="bool" label="1016" default="true"/>
 		<setting id="retries" type="slider" label="1017" range="1,1,10" default="3" option="int"/>
 	</category>
 	<category label="1040"><!-- Scrobbling -->

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -25,11 +25,11 @@ class Scrobbler(threading.Thread):
 	pinging = False
 	playlistLength = 1
 	abortRequested = False
-	VideoExcluded = False
 
 	def run(self):
 		# When requested ping trakt to say that the user is still watching the item
 		count = 0
+		Debug("Scrobbler starting.")
 		while (not (self.abortRequested or xbmc.abortRequested)):
 			xbmc.sleep(5000) # sleep for 5 seconds
 			if self.pinging and xbmc.Player().isPlayingVideo():
@@ -118,46 +118,8 @@ class Scrobbler(threading.Thread):
 	def startedWatching(self):
 		scrobbleMovieOption = __settings__.getSetting("scrobble_movie")
 		scrobbleEpisodeOption = __settings__.getSetting("scrobble_episode")
-		ExcludeLiveTV = __settings__.getSetting("ExcludeLiveTV")
-		ExcludeHTTP = __settings__.getSetting("ExcludeHTTP")		
-		ExcludePathOption = __settings__.getSetting("ExcludePathOption")
-		ExcludePathOption2 = __settings__.getSetting("ExcludePathOption2")
-		ExcludePathOption3 = __settings__.getSetting("ExcludePathOption3")
-		ExcludePath = __settings__.getSetting("ExcludePath")
-		ExcludePath2 = __settings__.getSetting("ExcludePath2")
-		ExcludePath3 = __settings__.getSetting("ExcludePath3")
-		
-		LiveTVExcluded = False
-		HTTPExcluded = False		
-		PathExcluded = False
 
-		currentPath = xbmc.Player().getPlayingFile()
-		if (currentPath.find("pvr://") > -1) and ExcludeLiveTV == 'true':
-			Debug("Video is playing via Live TV, which is currently set as excluded location.", False)
-			LiveTVExcluded = True			
-		if (currentPath.find("http://") > -1) and ExcludeHTTP == 'true':
-			Debug("Video is playing via HTTP source, which is currently set as excluded location.", False)
-			HTTPExcluded = True		
-		if  ExcludePath != "" and ExcludePathOption == 'true':
-			if (currentPath.find(ExcludePath) > -1):
-				Debug('Video is playing from location, which is currently set as excluded path 1.', False)
-				PathExcluded = True
-		if  ExcludePath2 != "" and ExcludePathOption2 == 'true':
-			currentPath = xbmc.Player().getPlayingFile()
-			if (currentPath.find(ExcludePath2) > -1):
-				Debug('Video is playing from location, which is currently set as excluded path 2.', False)
-				PathExcluded = True
-		if  ExcludePath3 != "" and ExcludePathOption3 == 'true':
-			currentPath = xbmc.Player().getPlayingFile()
-			if (currentPath.find(ExcludePath3) > -1):
-				Debug('Video is playing from location, which is currently set as excluded path 3.', False)
-				PathExcluded = True
-
-		if (LiveTVExcluded or HTTPExcluded or PathExcluded):
-			self.VideoExcluded = True
-			Debug("Video from excluded location was detected. No scrobbling!", False)
-
-		if self.curVideo['type'] == 'movie' and scrobbleMovieOption == 'true' and not self.VideoExcluded:
+		if self.curVideo['type'] == 'movie' and scrobbleMovieOption == 'true':
 			match = None
 			if 'id' in self.curVideo:
 				match = utilities.getMovieDetailsFromXbmc(self.curVideo['id'], ['imdbnumber', 'title', 'year'])
@@ -171,7 +133,7 @@ class Scrobbler(threading.Thread):
 			response = utilities.watchingMovieOnTrakt(match['imdbnumber'], match['title'], match['year'], self.totalTime/60, int(100*self.watchedTime/self.totalTime))
 			if response != None:
 				Debug("[Scrobbler] Watch response: "+str(response))
-		elif self.curVideo['type'] == 'episode' and scrobbleEpisodeOption == 'true' and not self.VideoExcluded:
+		elif self.curVideo['type'] == 'episode' and scrobbleEpisodeOption == 'true':
 			match = None
 			if 'id' in self.curVideo:
 				match = utilities.getEpisodeDetailsFromXbmc(self.curVideo['id'], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid'])
@@ -193,11 +155,11 @@ class Scrobbler(threading.Thread):
 		scrobbleMovieOption = __settings__.getSetting("scrobble_movie")
 		scrobbleEpisodeOption = __settings__.getSetting("scrobble_episode")
 
-		if self.curVideo['type'] == 'movie' and scrobbleMovieOption == 'true' and not self.VideoExcluded:
+		if self.curVideo['type'] == 'movie' and scrobbleMovieOption == 'true':
 			response = utilities.cancelWatchingMovieOnTrakt()
 			if response != None:
 				Debug("[Scrobbler] Cancel watch response: "+str(response))
-		elif self.curVideo['type'] == 'episode' and scrobbleEpisodeOption == 'true' and not self.VideoExcluded:
+		elif self.curVideo['type'] == 'episode' and scrobbleEpisodeOption == 'true':
 			response = utilities.cancelWatchingEpisodeOnTrakt()
 			if response != None:
 				Debug("[Scrobbler] Cancel watch response: "+str(response))
@@ -206,7 +168,7 @@ class Scrobbler(threading.Thread):
 		scrobbleMovieOption = __settings__.getSetting("scrobble_movie")
 		scrobbleEpisodeOption = __settings__.getSetting("scrobble_episode")
 
-		if self.curVideo['type'] == 'movie' and scrobbleMovieOption == 'true' and not self.VideoExcluded:
+		if self.curVideo['type'] == 'movie' and scrobbleMovieOption == 'true':
 			match = None
 			if 'id' in self.curVideo:
 				match = utilities.getMovieDetailsFromXbmc(self.curVideo['id'], ['imdbnumber', 'title', 'year'])
@@ -220,7 +182,7 @@ class Scrobbler(threading.Thread):
 			response = utilities.scrobbleMovieOnTrakt(match['imdbnumber'], match['title'], match['year'], self.totalTime/60, int(100*self.watchedTime/self.totalTime))
 			if response != None:
 				Debug("[Scrobbler] Scrobble response: "+str(response))
-		elif self.curVideo['type'] == 'episode' and scrobbleEpisodeOption == 'true' and not self.VideoExcluded:
+		elif self.curVideo['type'] == 'episode' and scrobbleEpisodeOption == 'true':
 			match = None
 			if 'id' in self.curVideo:
 				match = utilities.getEpisodeDetailsFromXbmc(self.curVideo['id'], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid'])

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -19,6 +19,7 @@ class Scrobbler(threading.Thread):
 	totalTime = 1
 	watchedTime = 0
 	startTime = 0
+	pausedTime = 0
 	curVideo = None
 	curVideoData = None
 	pinging = False
@@ -97,6 +98,7 @@ class Scrobbler(threading.Thread):
 			self.watchedTime += time.time() - self.startTime
 			Debug("[Scrobbler] Paused after: "+str(self.watchedTime))
 			self.startTime = 0
+			self.pausedTime = time.time()
 
 	def playbackEnded(self):
 		if self.startTime != 0:

--- a/utilities.py
+++ b/utilities.py
@@ -98,6 +98,44 @@ def checkSettings(daemon=False):
 def chunks(l, n):
 	return [l[i:i+n] for i in range(0, len(l), n)]
 
+# check exclusion settings for filename passed as argument
+def checkScrobblingExclusion(fullpath):
+
+	if not fullpath:
+		return True
+	
+	Debug("checkScrobblingExclusion(): Checking exclusion settings for '%s'" % fullpath)
+	
+	if (fullpath.find("pvr://") > -1) and get_bool_setting("ExcludeLiveTV"):
+		Debug("checkScrobblingExclusion(): Video is playing via Live TV, which is currently set as excluded location.")
+		return True
+				
+	if (fullpath.find("http://") > -1) and get_bool_setting("ExcludeHTTP"):
+		Debug("checkScrobblingExclusion(): Video is playing via HTTP source, which is currently set as excluded location.")
+		return True
+		
+	ExcludePath = get_string_setting("ExcludePath")
+	if ExcludePath != "" and get_bool_setting("ExcludePathOption"):
+		if (fullpath.find(ExcludePath) > -1):
+			Debug('checkScrobblingExclusion(): Video is playing from location, which is currently set as excluded path 1.')
+			return True
+
+	ExcludePath2 = get_string_setting("ExcludePath2")
+	if ExcludePath2 != "" and get_bool_setting("ExcludePathOption2"):
+		if (fullpath.find(ExcludePath2) > -1):
+			Debug('checkScrobblingExclusion(): Video is playing from location, which is currently set as excluded path 2.')
+			return True
+
+	ExcludePath3 = get_string_setting("ExcludePath3")
+	if ExcludePath3 != "" and get_bool_setting("ExcludePathOption3"):
+		if (fullpath.find(ExcludePath3) > -1):
+			Debug('checkScrobblingExclusion(): Video is playing from location, which is currently set as excluded path 3.')
+			return True
+	
+	return False
+
+
+
 # helper method to format api call url
 def formatTraktURL(req):
 

--- a/utilities.py
+++ b/utilities.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 
+import sys
 import xbmc
 import xbmcaddon
 import xbmcgui
@@ -12,9 +13,9 @@ import base64
 from urllib2 import HTTPError, URLError
 from httplib import HTTPException
 
-try:
+if sys.version_info < (2, 7):
 	import simplejson as json
-except ImportError:
+else:
 	import json
 
 # read settings
@@ -26,7 +27,6 @@ apikey = 'b6135e0f7510a44021fac8c03c36c81a17be35d9'
 username = __settings__.getSetting("username").strip()
 password = __settings__.getSetting("password").strip()
 debug = __settings__.getSetting("debug")
-retries = int(float(__settings__.getSetting("retries")))
 traktSettings = None
 
 def Debug(msg, force = False):
@@ -38,6 +38,22 @@ def Debug(msg, force = False):
 
 def notification( header, message, time=5000, icon=__settings__.getAddonInfo("icon")):
 	xbmc.executebuiltin( "XBMC.Notification(%s,%s,%i,%s)" % ( header, message, time, icon ) )
+
+# helper function to get bool type from settings
+def get_bool_setting(setting):
+	return __settings__.getSetting(setting) == 'true'
+
+# helper function to get string type from settings
+def get_string_setting(setting):
+	return __settings__.getSetting(setting).strip()
+
+# helper function to get int type from settings
+def get_int_setting(setting):
+	return int(get_float_setting(setting))
+
+# helper function to get float type from settings
+def get_float_setting(setting):
+	return float(__settings__.getSetting(setting))
 
 def xbmcJsonRequest(params):
 	data = json.dumps(params)
@@ -145,6 +161,7 @@ def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=
 	raw = None
 	data = None
 	jdata = {}
+	retries = get_int_setting("retries")
 
 	if not (method == 'POST' or method == 'GET'):
 		Debug("traktJsonRequest(): Unknown method '%s'" % method)


### PR DESCRIPTION
A nice long list of fixes:
- Add 4 helper functions to get settings in different types.
- Change the way json is imported in utils, use if, instead of a try block
- Change retries variable in utilities to be read every traktJsonRequest, instead of on plugin load, this way a change in that setting doesn't need a plugin restart.
- Remove HTTPS setting, and associated language string, since all requests are HTTPS now.
- Fix from ratings merge, a change done in notification rewrite was lost, pausedTime variable added.
- Fix for when a file is played directly, it will ignore it.
- Fix rating dialog always showing up.
- Change variables to use setting helper methods, to get values each call, instead of at plugin load.
- Add some checking on data returned via xbmc json, instead of referencing dictionary values directly.
- Add some more debug output in rating.py
- Move exclusion checking to a helper function in utilities.
- Change exclusion checking to be done in traktPlayer class, onPlayBackStarted, instead of every startedWatching call in scrobbler.
- This way the scrobbler is never initiated for the playback.

I've done some quick testing to make sure most stuff behaves, and it seems to, of course, more testing will be required.
