### PR TITLE
Migrate to a class based traktAPI usage

### DIFF
--- a/episode_sync.py
+++ b/episode_sync.py
@@ -3,18 +3,17 @@
 import xbmc
 import xbmcgui
 import xbmcaddon
-from utilities import traktJsonRequest, xbmcJsonRequest, Debug, notification, chunks
+from utilities import xbmcJsonRequest, Debug, notification, chunks, get_bool_setting
 
 __setting__   = xbmcaddon.Addon('script.trakt').getSetting
 __getstring__ = xbmcaddon.Addon('script.trakt').getLocalizedString
 
-add_episodes_to_trakt   = __setting__('add_episodes_to_trakt') == 'true'
-trakt_episode_playcount = __setting__('trakt_episode_playcount') == 'true'
-xbmc_episode_playcount  = __setting__('xbmc_episode_playcount') == 'true'
-clean_trakt_episodes  = __setting__('clean_trakt_episodes') == 'true'
+add_episodes_to_trakt = get_bool_setting('add_episodes_to_trakt')
+trakt_episode_playcount = get_bool_setting('trakt_episode_playcount')
+xbmc_episode_playcount = get_bool_setting('xbmc_episode_playcount')
+clean_trakt_episodes = get_bool_setting('clean_trakt_episodes')
 
 progress = xbmcgui.DialogProgress()
-
 
 def compare_show(xbmc_show, trakt_show):
 	missing = []
@@ -31,7 +30,6 @@ def compare_show(xbmc_show, trakt_show):
 
 	return missing
 
-
 def compare_show_watched_trakt(xbmc_show, trakt_show):
 	missing = []
 
@@ -47,7 +45,6 @@ def compare_show_watched_trakt(xbmc_show, trakt_show):
 
 	return missing
 
-
 def compare_show_watched_xbmc(xbmc_show, trakt_show):
 	missing = []
 
@@ -61,7 +58,12 @@ def compare_show_watched_xbmc(xbmc_show, trakt_show):
 	return missing
 
 class SyncEpisodes():
-	def __init__(self, show_progress=False):
+	def __init__(self, show_progress=False, api=None):
+		self.traktapi = api
+		if self.traktapi == None:
+			from traktapi import traktAPI
+			self.traktapi = traktAPI()
+			
 		self.xbmc_shows = []
 		self.trakt_shows = {'collection': [], 'watched': []}
 		self.notify = __setting__('show_sync_notifications') == 'true'
@@ -121,7 +123,7 @@ class SyncEpisodes():
 		if self.show_progress:
 			progress.update(15, line1=__getstring__(1434), line2=' ', line3=' ')
 
-		self.trakt_shows['collection'] = traktJsonRequest('POST', '/user/library/shows/collection.json/%%API_KEY%%/%%USERNAME%%/min')
+		self.trakt_shows['collection'] = self.traktapi.getShowLibrary()
 
 	def AddToTrakt(self):
 		Debug('[Episodes Sync] Checking for episodes missing from trakt.tv collection')
@@ -194,7 +196,7 @@ class SyncEpisodes():
 				if self.show_progress:
 					progress.update(45, line1=__getstring__(1435), line2=show['title'].encode('utf-8', 'ignore'), line3='%i %s' % (len(show['episodes']), __getstring__(1437)))
 
-				traktJsonRequest('POST', '/show/episode/library/%%API_KEY%%', show)
+				self.traktapi.addEpisode(show)
 
 		else:
 			Debug('[Episodes Sync] trakt.tv episode collection is up to date')
@@ -204,7 +206,7 @@ class SyncEpisodes():
 		if self.show_progress:
 			progress.update(50, line1=__getstring__(1438), line2=' ', line3=' ')
 
-		self.trakt_shows['watched'] = traktJsonRequest('POST', '/user/library/shows/watched.json/%%API_KEY%%/%%USERNAME%%/min')
+		self.trakt_shows['watched'] = self.traktapi.getWatchedEpisodeLibrary()
 
 	def UpdatePlaysTrakt(self):
 		Debug('[Episodes Sync] Checking watched episodes on trakt.tv')
@@ -275,7 +277,7 @@ class SyncEpisodes():
 				if self.show_progress:
 					progress.update(70, line1=__getstring__(1438), line2=show['title'].encode('utf-8', 'ignore'), line3='%i %s' % (len(show['episodes']), __getstring__(1440)))
 
-				traktJsonRequest('POST', '/show/episode/seen/%%API_KEY%%', show)
+				self.traktapi.updateSeenEpisode(show)
 
 		else:
 			Debug('[Episodes Sync] trakt.tv episode playcounts are up to date')
@@ -416,7 +418,7 @@ class SyncEpisodes():
 				if self.show_progress:
 					progress.update(95, line1=__getstring__(1445), line2=show['title'].encode('utf-8', 'ignore'), line3='%i %s' % (len(show['episodes']), __getstring__(1447)))
 
-				traktJsonRequest('POST', '/show/episode/unlibrary/%%API_KEY%%', show)
+				self.traktapi.removeEpisode(show)
 
 		else:
 			Debug('[Episodes Sync] trakt.tv episode collection is clean')

--- a/globals.py
+++ b/globals.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+#
+
+traktapi = None

--- a/notification_service.py
+++ b/notification_service.py
@@ -12,6 +12,7 @@ else:
 	import json
 
 import globals
+from traktapi import traktAPI
 from utilities import Debug, checkScrobblingExclusion, xbmcJsonRequest
 from scrobbler import Scrobbler
 from movie_sync import SyncMovies
@@ -62,6 +63,9 @@ class NotificationService:
 				episodes.Run()
 		elif action == "scanStarted":
 			pass
+		elif action == "settingsChanged":
+			Debug("[Notification] Settings changed, reloading.")
+			globals.traktapi.updateSettings()
 		else:
 			Debug("[Notification] '%s' unknown dispatch action!" % action)
 
@@ -72,6 +76,9 @@ class NotificationService:
 		self.Player = traktPlayer(action = self._dispatch)
 		self.Monitor = traktMonitor(action = self._dispatch)
 		
+		# init traktapi class
+		globals.traktapi = traktAPI()
+
 		# initalize scrobbler class
 		self._scrobbler = Scrobbler(globals.traktapi)
 
@@ -111,6 +118,11 @@ class traktMonitor(xbmc.Monitor):
 			Debug("[traktMonitor] onDatabaseScanStarted(database: %s)" % database)
 			data = {"action": "scanStarted"}
 			self.action(data)
+
+	def onSettingsChanged(self):
+		data = {"action": "settingsChanged"}
+		self.action(data)
+		
 
 class traktPlayer(xbmc.Player):
 

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -3,12 +3,11 @@
 
 import xbmc
 import xbmcaddon
-import sys
 import threading
 import time
 
 import utilities
-from utilities import Debug
+from utilities import Debug, get_float_setting
 from rating import ratingCheck
 
 # read settings
@@ -16,6 +15,8 @@ __settings__ = xbmcaddon.Addon("script.trakt")
 __language__ = __settings__.getLocalizedString
 
 class Scrobbler(threading.Thread):
+
+	traktapi = None
 	totalTime = 1
 	watchedTime = 0
 	startTime = 0
@@ -27,10 +28,15 @@ class Scrobbler(threading.Thread):
 	abortRequested = False
 	markFirstAsWatched = False
 
+	def __init__(self, api):
+		threading.Thread.__init__(self)
+		self.traktapi = api
+		self.start()
+
 	def run(self):
 		# When requested ping trakt to say that the user is still watching the item
 		count = 0
-		Debug("Scrobbler starting.")
+		Debug("[Scrobbler] Starting.")
 		while (not (self.abortRequested or xbmc.abortRequested)):
 			xbmc.sleep(5000) # sleep for 5 seconds
 			if self.pinging and xbmc.Player().isPlayingVideo():
@@ -38,14 +44,15 @@ class Scrobbler(threading.Thread):
 				self.watchedTime = xbmc.Player().getTime()
 				self.startTime = time.time()
 				if count >= 100:
-					self.startedWatching()
+					self.watching()
 					count = 0
 			else:
 				count = 0
 
-		Debug("Scrobbler stopping")
+		Debug("[Scrobbler] Stopping.")
 
 	def playbackStarted(self, data):
+		Debug("[Scrobbler] playbackStarted(data: %s)" % data)
 		if self.curVideo != None and self.curVideo != data['item']:
 			self.playbackEnded()
 		self.curVideo = data['item']
@@ -76,33 +83,42 @@ class Scrobbler(threading.Thread):
 					if (self.playlistLength == 0):
 						Debug("[Scrobbler] Warning: Cant find playlist length?!, assuming that this item is by itself")
 						self.playlistLength = 1
-				except:
-					Debug("[Scrobbler] Suddenly stopped watching item, or error: "+str(sys.exc_info()[0]))
+				except Exception, e:
+					Debug("[Scrobbler] Suddenly stopped watching item, or error: %s" % e.message)
 					self.curVideo = None
 					self.startTime = 0
 					return
 				self.startTime = time.time()
-				self.startedWatching()
+				self.watching()
 				self.pinging = True
 			else:
 				self.curVideo = None
 				self.startTime = 0
 
 	def playbackResumed(self):
+		Debug("[Scrobbler] playbackResumed()")
 		if self.pausedTime != 0:
 			p = time.time() - self.pausedTime
 			Debug("[Scrobbler] Resumed after: %s" % str(p))
 			self.pausedTime = 0
-			self.startedWatching()
-	
+			self.watching()
+
 	def playbackPaused(self):
+		Debug("[Scrobbler] playbackPaused()")
 		if self.startTime != 0:
 			self.watchedTime += time.time() - self.startTime
 			Debug("[Scrobbler] Paused after: "+str(self.watchedTime))
 			self.startTime = 0
 			self.pausedTime = time.time()
 
+	def playbackSeek(self):
+		Debug("[Scrobbler] playbackSeek()")
+		if self.startTime != 0:
+			self.watchedTime = xbmc.Player().getTime()
+			self.startTime = time.time()
+
 	def playbackEnded(self):
+		Debug("[Scrobbler] playbackEnded()")
 		if self.startTime != 0:
 			if self.curVideo == None:
 				Debug("[Scrobbler] Warning: Playback ended but video forgotten")
@@ -118,7 +134,8 @@ class Scrobbler(threading.Thread):
 			self.startTime = 0
 			self.curVideo = None
 
-	def startedWatching(self):
+	def watching(self):
+		Debug("[Scrobbler] watching()")
 		scrobbleMovieOption = __settings__.getSetting("scrobble_movie")
 		scrobbleEpisodeOption = __settings__.getSetting("scrobble_episode")
 
@@ -133,9 +150,13 @@ class Scrobbler(threading.Thread):
 				match['year'] = self.curVideoData['year']
 			if match == None:
 				return
-			response = utilities.watchingMovieOnTrakt(match['imdbnumber'], match['title'], match['year'], self.totalTime/60, int(100*self.watchedTime/self.totalTime))
+			
+			duration = self.totalTime / 60
+			watchedPercent = int((self.watchedTime / self.totalTime) * 100)
+			response = self.traktapi.watchingMovie(match['imdbnumber'], match['title'], match['year'], duration, watchedPercent)
 			if response != None:
 				Debug("[Scrobbler] Watch response: "+str(response))
+				
 		elif self.curVideo['type'] == 'episode' and scrobbleEpisodeOption == 'true':
 			match = None
 			if 'id' in self.curVideo:
@@ -144,7 +165,7 @@ class Scrobbler(threading.Thread):
 						# force a scrobble of the first episode
 						Debug("[Scrobbler] Attempting to mark first episode in a double episode as watched.")
 						firstEP = utilities.getEpisodeDetailsFromXbmc(self.curVideo['id'], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid'])
-						response = utilities.scrobbleEpisodeOnTrakt(firstEP['tvdb_id'], firstEP['showtitle'], firstEP['year'], firstEP['season'], firstEP['episode'], firstEP['uniqueid']['unknown'], self.totalTime/60, 100)
+						response = self.traktapi.scrobbleEpisode(firstEP['tvdb_id'], firstEP['showtitle'], firstEP['year'], firstEP['season'], firstEP['episode'], firstEP['uniqueid']['unknown'], self.totalTime/60, 100)
 						if response != None:
 							Debug("[Scrobbler] Scrobble response: %s" % str(response))
 						self.markFirstAsWatched = True
@@ -163,24 +184,29 @@ class Scrobbler(threading.Thread):
 				match['uniqueid'] = self.curVideoData['uniqueid']['unknown']
 			if match == None:
 				return
-			response = utilities.watchingEpisodeOnTrakt(match['tvdb_id'], match['showtitle'], match['year'], match['season'], match['episode'], match['uniqueid']['unknown'], self.totalTime/60, int(100*self.watchedTime/self.totalTime))
+				
+			duration = self.totalTime / 60
+			watchedPercent = int((self.watchedTime / self.totalTime) * 100)
+			response = self.traktapi.watchingEpisode(match['tvdb_id'], match['showtitle'], match['year'], match['season'], match['episode'], match['uniqueid']['unknown'], duration, watchedPercent)
 			if response != None:
 				Debug("[Scrobbler] Watch response: "+str(response))
 
 	def stoppedWatching(self):
+		Debug("[Scrobbler] stoppedWatching()")
 		scrobbleMovieOption = __settings__.getSetting("scrobble_movie")
 		scrobbleEpisodeOption = __settings__.getSetting("scrobble_episode")
 
 		if self.curVideo['type'] == 'movie' and scrobbleMovieOption == 'true':
-			response = utilities.cancelWatchingMovieOnTrakt()
+			response = self.traktapi.cancelWatchingMovie()
 			if response != None:
 				Debug("[Scrobbler] Cancel watch response: "+str(response))
 		elif self.curVideo['type'] == 'episode' and scrobbleEpisodeOption == 'true':
-			response = utilities.cancelWatchingEpisodeOnTrakt()
+			response = self.traktapi.cancelWatchingEpisode()
 			if response != None:
 				Debug("[Scrobbler] Cancel watch response: "+str(response))
 
 	def scrobble(self):
+		Debug("[Scrobbler] scrobble()")
 		scrobbleMovieOption = __settings__.getSetting("scrobble_movie")
 		scrobbleEpisodeOption = __settings__.getSetting("scrobble_episode")
 
@@ -195,9 +221,13 @@ class Scrobbler(threading.Thread):
 				match['year'] = self.curVideoData['year']
 			if match == None:
 				return
-			response = utilities.scrobbleMovieOnTrakt(match['imdbnumber'], match['title'], match['year'], self.totalTime/60, int(100*self.watchedTime/self.totalTime))
+
+			duration = self.totalTime / 60
+			watchedPercent = int((self.watchedTime / self.totalTime) * 100)
+			response = self.traktapi.scrobbleMovie(match['imdbnumber'], match['title'], match['year'], duration, watchedPercent)
 			if response != None:
 				Debug("[Scrobbler] Scrobble response: "+str(response))
+
 		elif self.curVideo['type'] == 'episode' and scrobbleEpisodeOption == 'true':
 			match = None
 			if 'id' in self.curVideo:
@@ -216,16 +246,18 @@ class Scrobbler(threading.Thread):
 				match['uniqueid'] = self.curVideoData['uniqueid']['unknown']
 			if match == None:
 				return
-			response = utilities.scrobbleEpisodeOnTrakt(match['tvdb_id'], match['showtitle'], match['year'], match['season'], match['episode'], match['uniqueid']['unknown'], self.totalTime/60, int(100*self.watchedTime/self.totalTime))
+			
+			duration = self.totalTime / 60
+			watchedPercent = int((self.watchedTime / self.totalTime) * 100)
+			response = self.traktapi.scrobbleEpisode(match['tvdb_id'], match['showtitle'], match['year'], match['season'], match['episode'], match['uniqueid']['unknown'], duration, watchedPercent)
 			if response != None:
 				Debug("[Scrobbler] Scrobble response: "+str(response))
 
 	def check(self):
-		__settings__ = xbmcaddon.Addon("script.trakt") #read settings again, encase they have changed
-		scrobbleMinViewTimeOption = __settings__.getSetting("scrobble_min_view_time")
+		scrobbleMinViewTimeOption = get_float_setting("scrobble_min_view_time")
 
-		Debug("watched: " + str(self.watchedTime) + " / " + str(self.totalTime))
-		if (self.watchedTime/self.totalTime)*100>=float(scrobbleMinViewTimeOption):
+		Debug("[Scrobbler] watched: %s / %s" % (str(self.watchedTime), str(self.totalTime)))
+		if ((self.watchedTime / self.totalTime) * 100) >= scrobbleMinViewTimeOption:
 			self.scrobble()
 		else:
 			self.stoppedWatching()

--- a/service.py
+++ b/service.py
@@ -2,9 +2,7 @@
 #
 
 import xbmcaddon
-import globals
 from utilities import Debug
-from traktapi import traktAPI
 from notification_service import NotificationService
 
 __addon__ = xbmcaddon.Addon("script.trakt")
@@ -16,9 +14,6 @@ Debug("Loading '%s' version '%s'" % (__addonid__, __addonversion__))
 
 # starts update/sync
 def autostart():
-
-	# init traktapi class
-	globals.traktapi = traktAPI()
 
 	# startup notification
 	NotificationService()

--- a/service.py
+++ b/service.py
@@ -2,7 +2,9 @@
 #
 
 import xbmcaddon
-from utilities import Debug, checkSettings, getTraktSettings
+import globals
+from utilities import Debug
+from traktapi import traktAPI
 from notification_service import NotificationService
 
 __addon__ = xbmcaddon.Addon("script.trakt")
@@ -14,10 +16,12 @@ Debug("Loading '%s' version '%s'" % (__addonid__, __addonversion__))
 
 # starts update/sync
 def autostart():
-	if checkSettings(True):
-		getTraktSettings()
-		# startup notifcation service
-		NotificationService()
+
+	# init traktapi class
+	globals.traktapi = traktAPI()
+
+	# startup notification
+	NotificationService()
 	
 	Debug("Plugin shutting down.")
 

--- a/sync_exec.py
+++ b/sync_exec.py
@@ -2,6 +2,7 @@
 
 import xbmcaddon
 import xbmcgui
+import globals
 from movie_sync import SyncMovies
 from episode_sync import SyncEpisodes
 
@@ -20,9 +21,9 @@ def do_sync(media_type):
 
 if __name__ == '__main__':
 	if do_sync('movies'):
-		movies = SyncMovies(show_progress=True)
+		movies = SyncMovies(show_progress=True, api=globals.traktapi)
 		movies.Run()
 
 	if do_sync('episodes'):
-		episodes = SyncEpisodes(show_progress=True)
+		episodes = SyncEpisodes(show_progress=True, api=globals.traktapi)
 		episodes.Run()

--- a/traktapi.py
+++ b/traktapi.py
@@ -261,7 +261,7 @@ class traktAPI(object):
 		_username = get_string_setting("username")
 		_password = sha1(get_string_setting("password")).hexdigest()
 		
-		if not ((self.__username == _username) or (self.__password == _password)):
+		if not ((self.__username == _username) and (self.__password == _password)):
 			self.__username = _username
 			self.__password = _password
 			self.testAccount(force=True)

--- a/traktapi.py
+++ b/traktapi.py
@@ -1,0 +1,429 @@
+# -*- coding: utf-8 -*-
+#
+
+import xbmc
+import xbmcaddon
+import xbmcgui
+import time, socket
+import math
+import urllib2
+import base64
+
+from utilities import Debug, notification, get_string_setting, get_bool_setting, get_int_setting
+from urllib2 import Request, urlopen, HTTPError, URLError
+from httplib import HTTPException
+
+try:
+	import simplejson as json
+except ImportError:
+	import json
+
+try:
+	from hashlib import sha1
+except ImportError:
+	from sha import new as sha1
+
+# read settings
+__addon__ = xbmcaddon.Addon("script.trakt")
+__addonversion__ = __addon__.getAddonInfo("version")
+__language__ = __addon__.getLocalizedString
+
+class traktAuthProblem(Exception):
+	def __init__(self, value, code):
+		self.value = value
+		self.code = code
+	def __str__(self):
+		return repr(self.value)
+class traktServerBusy(Exception):
+	def __init__(self, value, code):
+		self.value = value
+		self.code = code
+	def __str__(self):
+		return repr(self.value)
+
+class traktAPI(object):
+
+	__apikey = "b6135e0f7510a44021fac8c03c36c81a17be35d9"
+	__baseURL = "https://api.trakt.tv"
+	__timeout = 60
+	validUser = False
+
+	def __init__(self):
+		username = get_string_setting("username")
+		Debug("[traktAPI] Initializing")
+		Debug("[traktAPI] Testing account '%s'" % username)
+		self.settings = None
+		if self.testAccount():
+			Debug("[traktAPI] Account '%s' is valid." % username)
+			Debug("[traktAPI] Getting account settings for '%s'" % username)
+			self.getAccountSettings()
+		else:
+			Debug("[traktAPI] Account '%s' is not valid." % username)
+
+	def __getData(self, url, args):
+		data = None
+		try:
+			Debug("[traktAPI] __getData(): urllib2.Request(%s)" % url)
+
+			if args == None:
+				req = Request(url)
+			else:
+				req = Request(url, args)
+
+			Debug("[traktAPI] __getData(): urllib2.urlopen()")
+			t1 = time.time()
+			response = urlopen(req, timeout=self.__timeout)
+			t2 = time.time()
+
+			Debug("[traktAPI] __getData(): response.read()")
+			data = response.read()
+
+			Debug("[traktAPI] __getData(): Response Code: %i" % response.getcode())
+			Debug("[traktAPI] __getData(): Response Time: %0.2f ms" % ((t2 - t1) * 1000))
+			Debug("[traktAPI] __getData(): Response Headers: %s" % str(response.info().dict))
+
+		except IOError, e:
+			if hasattr(e, "code"): # error 401 or 503, possibly others
+				Debug("[traktAPI] __getData(): Error Code: %s" % str(e.code))
+				
+				error = {}
+
+				# read the error document, strip newlines, this will make an html page 1 line
+				error_data = e.read().replace("\n", "").replace("\r", "")
+
+				# try to parse the data as json
+				try:
+					error = json.loads(error_data)
+				except ValueError:
+					Debug("[traktAPI] __getData(): Error data is not JSON format - %s" % error_data)
+					# manually add status, and the page data returned.
+					error["status"] = "failure"
+					error["error"] = error_data
+
+				# add error code, and string type to error dictionary
+				error["code"] = e.code
+				error["type"] = "protocol"
+
+				if e.code == 401: # authentication problem
+					# {"status":"failure","error":"failed authentication"}
+					Debug("[traktAPI] __getData(): Authentication Failure (%s)" % error_data)
+					# reset internal valid user
+					self.validUser = False
+
+				elif e.code == 503: # server busy problem
+					# {"status":"failure","error":"server is over capacity"}
+					Debug("[traktAPI] __getData(): Server Busy (%s)" % error_data)
+
+				else:
+					Debug("[traktAPI] __getData(): Other problem (%s)" % error_data)
+
+				return json.dumps(error)
+			elif hasattr(e, "reason"): # usually a read timeout, or unable to reach host
+				Debug("[traktAPI] __getData(): Network error: %s" % str(e.reason))
+				if isinstance(e.reason, socket.timeout):
+					notification("trakt", __language__(1108).encode( "utf-8", "ignore" ) + " (timeout)") # can't connect to trakt
+				return '{"status":"failure","error":"%s","type":"network"}' % e.reason
+			else:
+				return '{"status":"failure","error":"%s"}' % e.message
+		return data
+	
+	# make a JSON api request to trakt
+	# method: http method (GET or POST)
+	# req: REST request (ie '/user/library/movies/all.json/%%API_KEY%%/%%USERNAME%%')
+	# args: arguments to be passed by POST JSON (only applicable to POST requests), default:{}
+	# returnStatus: when unset or set to false the function returns None upon error and shows a notification,
+	#	when set to true the function returns the status and errors in ['error'] as given to it and doesn't show the notification,
+	#	use to customise error notifications
+	# silent: default is True, when true it disable any error notifications (but not debug messages)
+	# passVersions: default is False, when true it passes extra version information to trakt to help debug problems
+	# hideResponse: used to not output the json response to the log
+	def traktRequest(self, method, url, args=None, returnStatus=False, silent=True, passVersions=False, hideResponse=False):
+		raw = None
+		data = None
+		jdata = {}
+		retries = get_int_setting("retries")
+
+		if args is None:
+			args = {}
+
+		if not (method == 'POST' or method == 'GET'):
+			Debug("[traktAPI] traktRequest(): Unknown method '%s'" % method)
+			return None
+		
+		if method == 'POST':
+			# debug log before username and sha1hash are injected
+			Debug("[traktAPI] traktRequest(): Request data: '%s'" % str(json.dumps(args)))
+			
+			# inject username/pass into json data
+			args["username"] = get_string_setting("username")
+			args["password"] = sha1(get_string_setting("password")).hexdigest()
+			
+			# check if plugin version needs to be passed
+			if passVersions:
+				args['plugin_version'] = __addonversion__
+				args['media_center_version'] = xbmc.getInfoLabel("system.buildversion")
+				args['media_center_date'] = xbmc.getInfoLabel("system.builddate")
+			
+			# convert to json data
+			jdata = json.dumps(args)
+
+		Debug("[traktAPI] traktRequest(): Starting retry loop, maximum %i retries." % retries)
+		
+		# start retry loop
+		for i in range(retries):	
+			Debug("[traktAPI] traktRequest(): (%i) Request URL '%s'" % (i, url))
+			
+			# get data from trakt.tv
+			raw = self.__getData(url, jdata)
+			
+			# check if we are closing
+			if xbmc.abortRequested:
+				Debug("[traktAPI] traktRequest(): (%i) xbmc.abortRequested" % i)
+				break
+
+			# check that returned data is not empty
+			if not raw:
+				Debug("[traktAPI] traktRequest(): (%i) JSON Response empty" % i)
+				xbmc.sleep(1000)
+				continue
+
+			try:
+				# get json formatted data	
+				data = json.loads(raw)
+				if hideResponse:
+					Debug("[traktAPI] traktRequest(): (%i) JSON response recieved, response not logged" % i)
+				else:
+					Debug("[traktAPI] traktRequest(): (%i) JSON response: '%s'" % (i, str(data)))
+			except ValueError:
+				# malformed json response
+				Debug("[traktAPI] traktRequest(): (%i) Bad JSON response: '%s'", (i, raw))
+				if not silent:
+					notification("trakt", __language__(1109).encode( "utf-8", "ignore" ) + ": Bad response from trakt") # Error
+				
+			# check for the status variable in JSON data
+			if 'status' in data:
+				if data['status'] == 'success':
+					break
+				else:
+					Debug("[traktAPI] traktRequest(): (%i) JSON Error '%s' -> '%s'" % (i, data['status'], data['error']))
+					if data.has_key("type"):
+						if data["type"] == "protocol":
+							# protocol error, so a 4xx or 5xx
+							if data["code"] == 401:
+								# auth error, no point retrying
+								self.validUser = False
+								return None
+							else:
+								pass
+						elif data["type"] == "network":
+							# network communication error, sleep for a
+							# bit longer before continuing
+							xbmc.sleep(5000)
+							continue
+					else:
+						#should never get here
+						pass
+					
+					xbmc.sleep(1000)
+					continue
+			
+			# check to see if we have data
+			if data:
+				Debug("[traktAPI] traktRequest(): Have JSON data, breaking retry.")
+				break
+
+			xbmc.sleep(500)
+		
+		# handle scenario where all retries fail
+		if not data:
+			Debug("[traktAPI] traktRequest(): JSON Request failed, data is still empty after retries.")
+			return None
+		
+		if 'status' in data:
+			if data['status'] == 'failure':
+				Debug("[traktAPI] traktRequest(): Error: %s" % str(data['error']))
+				if returnStatus:
+					return data
+				if not silent:
+					notification("trakt", __language__(1109).encode( "utf-8", "ignore" ) + ": " + str(data['error'])) # Error
+				return None
+			elif data['status'] == 'success':
+				Debug("[traktAPI] traktRequest(): JSON request was successful.")
+
+		return data
+
+	# http://api.trakt.tv/account/test/<apikey>
+	# returns: {"status": "success","message": "all good!"}
+	def testAccount(self, daemon=True):
+		
+		if get_string_setting("username") == "":
+			notification("trakt", __language__(1106).encode("utf-8", "ignore")) # please enter your Username and Password in settings
+			return False
+		elif get_string_setting("password") == "":
+			notification("trakt", __language__(1107).encode("utf-8", "ignore")) # please enter your Password in settings
+			return False
+
+		if not self.validUser:
+			url = "%s/account/test/%s" % (self.__baseURL, self.__apikey)
+			Debug("[traktAPI] testAccount(url: %s)" % url)
+			response = self.traktRequest("POST", url)
+			if response:
+				if response.has_key("status"):
+					if response["status"] == "success":
+						self.validUser = True
+						return True
+		else:
+			return True
+
+		notification("trakt", __language__(1110).encode("utf-8", "ignore")) # please enter your Password in settings
+		return False
+
+	# url: http://api.trakt.tv/account/settings/<apikey>
+	# returns: all settings for authenticated user
+	def getAccountSettings(self):
+		if self.testAccount():
+			url = "%s/account/settings/%s" % (self.__baseURL, self.__apikey)
+			Debug("[traktAPI] getAccountSettings(url: %s)" % url)
+			response = self.traktRequest("POST", url, hideResponse=True)
+			if response:
+				if response.has_key("status"):
+					if response["status"] == "success":
+						self.settings = response
+
+	# url: http://api.trakt.tv/<show|movie>/watching/<apikey>
+	# returns: {"status":"success","message":"watching The Walking Dead 1x01","show":{"title":"The Walking Dead","year":"2010","imdb_id":"tt123456","tvdb_id":"153021","tvrage_id":"1234"},"season":"1","episode":{"number":"1","title":"Days Gone Bye"},"facebook":false,"twitter":false,"tumblr":false}
+	def watching(self, type, data):
+		if self.testAccount():
+			url = "%s/%s/watching/%s" % (self.__baseURL, type, self.__apikey)
+			Debug("[traktAPI] watching(url: %s, data: %s)" % (url, str(data)))
+			return self.traktRequest("POST", url, data, passVersions=True)
+	
+	def watchingEpisode(self, tvdb_id, title, year, season, episode, uniqueid, duration, percent):
+		data = {'tvdb_id': tvdb_id, 'title': title, 'year': year, 'season': season, 'episode': episode, 'episode_tvdb_id': uniqueid, 'duration': math.ceil(duration), 'progress': math.ceil(percent)}
+		return self.watching("show", data)
+	def watchingMovie(self, imdb_id, title, year, duration, percent):
+		data = {'imdb_id': imdb_id, 'title': title, 'year': year, 'duration': math.ceil(duration), 'progress': math.ceil(percent)}
+		return self.watching("movie", data)
+
+	# url: http://api.trakt.tv/<show|movie>/scrobble/<apikey>
+	# returns: {"status": "success","message": "scrobbled The Walking Dead 1x01"}
+	def scrobble(self, type, data):
+		if self.testAccount():
+			url = "%s/%s/scrobble/%s" % (self.__baseURL, type, self.__apikey)
+			Debug("[traktAPI] scrobble(url: %s, data: %s)" % (url, str(data)))
+			return self.traktRequest("POST", url, data, passVersions=True)
+
+	def scrobbleEpisode(self, tvdb_id, title, year, season, episode, uniqueid, duration, percent):
+		data = {'tvdb_id': tvdb_id, 'title': title, 'year': year, 'season': season, 'episode': episode, 'episode_tvdb_id': uniqueid, 'duration': math.ceil(duration), 'progress': math.ceil(percent)}
+		return self.scrobble("show", data)
+	def scrobbleMovie(self, imdb_id, title, year, duration, percent):
+		data = {'imdb_id': imdb_id, 'title': title, 'year': year, 'duration': math.ceil(duration), 'progress': math.ceil(percent)}
+		return self.scrobble("movie", data)
+
+	# url: http://api.trakt.tv/<show|movie>/cancelwatching/<apikey>
+	# returns: {"status":"success","message":"cancelled watching"}
+	def cancelWatching(self, type):
+		if self.testAccount():
+			url = "%s/%s/cancelwatching/%s" % (self.__baseURL, type, self.__apikey)
+			Debug("[traktAPI] cancelWatching(url: %s)" % url)
+			return self.traktRequest("POST", url)
+		
+	def cancelWatchingEpisode(self):
+		return self.cancelWatching("show")
+	def cancelWatchingMovie(self):
+		return self.cancelWatching("movie")
+
+	# url: http://api.trakt.tv/user/library/<shows|movies>/collection.json/<apikey>/<username>/min
+	# response: [{"title":"Archer (2009)","year":2009,"imdb_id":"tt1486217","tvdb_id":110381,"seasons":[{"season":2,"episodes":[1,2,3,4,5]},{"season":1,"episodes":[1,2,3,4,5,6,7,8,9,10]}]}]
+	# note: if user has nothing in collection, response is then []
+	def getLibrary(self, type):
+		if self.testAccount():
+			url = "%s/user/library/%s/collection.json/%s/%s/min" % (self.__baseURL, type, self.__apikey, get_string_setting("username"))
+			Debug("[traktAPI] getLibrary(url: %s)" % url)
+			return self.traktRequest("POST", url)
+
+	def getShowLibrary(self):
+		return self.getLibrary("shows")
+	def getMovieLibrary(self):
+		return self.getLibrary("movies")
+
+	# url: http://api.trakt.tv/user/library/<shows|movies>/watched.json/<apikey>/<username>/min
+	# returns: [{"title":"Archer (2009)","year":2009,"imdb_id":"tt1486217","tvdb_id":110381,"seasons":[{"season":2,"episodes":[1,2,3,4,5]},{"season":1,"episodes":[1,2,3,4,5,6,7,8,9,10]}]}]
+	# note: if nothing watched in collection, returns []
+	def getWatchedLibrary(self, type):
+		if self.testAccount():
+			url = "%s/user/library/%s/watched.json/%s/%s/min" % (self.__baseURL, type, self.__apikey, get_string_setting("username"))
+			Debug("[traktAPI] getWatchedLibrary(url: %s)" % url)
+			return self.traktRequest("POST", url)
+
+	def getWatchedEpisodeLibrary(self,):
+		return self.getWatchedLibrary("shows")
+	def getWatchedMovieLibrary(self):
+		return self.getWatchedLibrary("movies")
+
+	# url: http://api.trakt.tv/<show/episode|movie>/library/<apikey>
+	# returns: {u'status': u'success', u'message': u'27 episodes added to your library'}
+	def addToLibrary(self, type, data):
+		if self.testAccount():
+			url = "%s/%s/library/%s" % (self.__baseURL, type, self.__apikey)
+			Debug("[traktAPI] addToLibrary(url: %s, data: %s)" % (url, str(data)))
+			return self.traktRequest("POST", url, data)
+
+	def addEpisode(self, data):
+		return self.addToLibrary("show/episode", data)
+	def addMovie(self, data):
+		return self.addToLibrary("movie", data)
+
+	# url: http://api.trakt.tv/<show/episode|movie>/unlibrary/<apikey>
+	# returns:
+	def removeFromLibrary(self, type, data):
+		if self.testAccount():
+			url = "%s/%s/unlibrary/%s" % (self.__baseURL, type, self.__apikey)
+			Debug("[traktAPI] removeFromLibrary(url: %s, data: %s)" % (url, str(data)))
+			return self.traktRequest("POST", url, data)
+
+	def removeEpisode(self, data):
+		return self.removeFromLibrary("show/episode", data)
+	def removeMovie(self, date):
+		return self.removeFromLibrary("movie", data)
+
+	# url: http://api.trakt.tv/<show/episode|movie>/seen/<apikey>
+	# returns: {u'status': u'success', u'message': u'2 episodes marked as seen'}
+	def updateSeenInLibrary(self, type, data):
+		if self.testAccount():
+			url = "%s/%s/seen/%s" % (self.__baseURL, type, self.__apikey)
+			Debug("[traktAPI] updateSeenInLibrary(url: %s, data: %s)" % (url, str(data)))
+			return self.traktRequest("POST", url, data)
+
+	def updateSeenEpisode(self, data):
+		return self.updateSeenInLibrary("show/episode", data)
+	def updateSeenMovie(self, data):
+		return self.updateSeenInLibrary("movie", data)
+
+	# url: http://api.trakt.tv/<show/episode|movie>/summary.format/apikey/title[/season/episode]
+	# returns: returns information for a movie or episode
+	def getSummary(self, type, data):
+		if self.testAccount():
+			url = "%s/%s/summary.json/%s/%s" % (self.__baseURL, type, self.__apikey, data)
+			Debug("[traktAPI] getSummary(url: %s)" % url)
+			return self.traktRequest("POST", url)
+
+	def getShowSummary(self, imdb_id, season, episode):
+		data = "%s/%s/%s" % (imdb_id, season, episode)
+		return self.getSummary("show/episode", data)
+	def getMovieSummary(self, imdb_id):
+		data = str(imdb_id)
+		return self.getSummary("movie", data)
+
+	# url: http://api.trakt.tv/rate/<episode|movie>/apikey
+	# returns: {"status":"success","message":"rated Portlandia 1x01","type":"episode","rating":"love","ratings":{"percentage":100,"votes":2,"loved":2,"hated":0},"facebook":true,"twitter":true,"tumblr":false}
+	def rate(self, type, data):
+		if self.testAccount():
+			url = "%s/rate/%s/%s" % (self.__baseURL, type, self.__apikey)
+			Debug("[traktAPI] rate(url: %s, data: %s)" % (url, str(data)))
+			return self.traktRequest("POST", url, data, passVersions=True)
+
+	def rateEpisode(self, data):
+		return self.rate("episode", data)
+	def rateMovie(self, data):
+		return self.rate("movie", data)

--- a/utilities.py
+++ b/utilities.py
@@ -4,34 +4,18 @@
 import xbmc
 import xbmcaddon
 import xbmcgui
-import time, socket
 import math
-import urllib2
-import base64
-
-from urllib2 import HTTPError, URLError
-from httplib import HTTPException
 
 try:
 	import simplejson as json
 except ImportError:
 	import json
 
-try:
-	from hashlib import sha1
-except ImportError:
-	from sha import new as sha1
-
 # read settings
 __settings__ = xbmcaddon.Addon("script.trakt")
 __language__ = __settings__.getLocalizedString
 
-apikey = 'b6135e0f7510a44021fac8c03c36c81a17be35d9'
-
-username = __settings__.getSetting("username").strip()
-pwd = sha1(__settings__.getSetting("password")).hexdigest()
 debug = __settings__.getSetting("debug")
-traktSettings = None
 
 def Debug(msg, force = False):
 	if(debug == 'true' or force):
@@ -72,33 +56,6 @@ def xbmcJsonRequest(params):
 		Debug("[%s] %s" % (params["method"], response["error"]["message"]), True)
 		return None
 
-def checkSettings(daemon=False):
-	if username == "":
-		if daemon:
-			notification("trakt", __language__(1106).encode( "utf-8", "ignore" )) # please enter your Username and Password in settings
-		else:
-			xbmcgui.Dialog().ok("trakt", __language__(1106).encode( "utf-8", "ignore" )) # please enter your Username and Password in settings
-			__settings__.openSettings()
-		return False
-	elif __settings__.getSetting("password") == "":
-		if daemon:
-			notification("trakt", __language__(1107).encode( "utf-8", "ignore" )) # please enter your Password in settings
-		else:
-			xbmcgui.Dialog().ok("trakt", __language__(1107).encode( "utf-8", "ignore" )) # please enter your Password in settings
-			__settings__.openSettings()
-		return False
-
-	data = traktJsonRequest('POST', '/account/test/%%API_KEY%%', silent=True)
-	if data == None: #Incorrect trakt login details
-		if daemon:
-			notification("trakt", __language__(1110).encode( "utf-8", "ignore" )) # please enter your Password in settings
-		else:
-			xbmcgui.Dialog().ok("trakt", __language__(1110).encode( "utf-8", "ignore" )) # please enter your Password in settings
-			__settings__.openSettings()
-		return False
-
-	return True
-
 def chunks(l, n):
 	return [l[i:i+n] for i in range(0, len(l), n)]
 
@@ -137,148 +94,6 @@ def checkScrobblingExclusion(fullpath):
 			return True
 	
 	return False
-
-
-
-# helper method to format api call url
-def formatTraktURL(req):
-
-	# default to always https
-	url = "https://api.trakt.tv" + req
-	
-	# replace api and username values
-	url = url.replace("%%API_KEY%%", apikey)
-	url = url.replace("%%USERNAME%%", username)
-	
-	return url
-
-# helper function for making requests through urllib2
-def get_data(url, args):
-	data = None
-	try:
-		Debug("get_data(): urllib2.Request(%s)" % url)
-		if args == None:
-			req = urllib2.Request(url)
-		else:
-			req = urllib2.Request(url, args)
-			# add basic http header authentication
-			base64string = base64.encodestring('%s:%s' % (username, pwd)).replace('\n', '')
-			req.add_header("Authorization", "Basic %s" % base64string)
-		Debug("get_data(): urllib2.urlopen()")
-		response = urllib2.urlopen(req)
-		Debug("get_data(): response.read()")
-		data = response.read()
-	except socket.timeout:
-		Debug("get_data(): can't connect to trakt - timeout")
-		notification("trakt", __language__(1108).encode( "utf-8", "ignore" ) + " (timeout)") # can't connect to trakt
-		return None
-	except HTTPError, e:
-		Debug("get_data(): HTTPError = %s" % str(e.code))
-		return None
-	except URLError, e:
-		Debug("get_data(): URLError = %s" % str(e.reason))
-		return None
-	except HTTPException, e:
-		Debug("get_data(): HTTPException")
-		return None
-	except Exception:
-		import traceback
-		Debug("get_data(): Generic exception: %s" % traceback.format_exc())
-		return None
-
-	return data
-
-# make a JSON api request to trakt
-# method: http method (GET or POST)
-# req: REST request (ie '/user/library/movies/all.json/%%API_KEY%%/%%USERNAME%%')
-# args: arguments to be passed by POST JSON (only applicable to POST requests), default:{}
-# returnStatus: when unset or set to false the function returns None apon error and shows a notification,
-#	when set to true the function returns the status and errors in ['error'] as given to it and doesn't show the notification,
-#	use to customise error notifications
-# anon: anonymous (dont send username/password), default:False
-# connection: default it to make a new connection but if you want to keep the same one alive pass it here
-# silent: default is True, when true it disable any error notifications (but not debug messages)
-# passVersions: default is False, when true it passes extra version information to trakt to help debug problems
-def traktJsonRequest(method, req, args={}, returnStatus=False, anon=False, conn=False, silent=True, passVersions=False):
-	raw = None
-	data = None
-	jdata = {}
-	retries = get_int_setting("retries")
-
-	if not (method == 'POST' or method == 'GET'):
-		Debug("traktJsonRequest(): Unknown method '%s'" % method)
-		return None
-	
-	# get trakt api url to open
-	url = formatTraktURL(req)
-	
-	if method == 'POST':
-		if passVersions:
-			args['plugin_version'] = __settings__.getAddonInfo("version")
-			args['media_center_version'] = xbmc.getInfoLabel("system.buildversion")
-			args['media_center_date'] = xbmc.getInfoLabel("system.builddate")
-		jdata = json.dumps(args)
-		Debug("traktJsonRequest(): Request Data: '%s'" % str(jdata))
-
-	Debug("traktJsonRequest(): Starting retry loop, maximum %i retries." % retries)
-	
-	for i in range(0,retries):	
-		try:
-			Debug("traktJsonRequest(): (%i) Request URL '%s'" % (i, url))
-			raw = get_data(url, jdata)
-			if xbmc.abortRequested:
-				Debug("traktJsonRequest(): (%i) xbmc.abortRequested" % i)
-				break
-			if not raw:
-				Debug("traktJsonRequest(): (%i) JSON Response empty" % i)
-				time.sleep(0.1)
-				continue
-				
-			# get json formatted data	
-			data = json.loads(raw)
-			Debug("traktJsonRequest(): (%i) JSON response: '%s'" % (i, str(data)))
-			
-			# check for the status variable in JSON data
-			if 'status' in data:
-				if data['status'] == 'success':
-					break
-				else:
-					Debug("traktJsonRequest(): (%i) JSON Error '%s' -> '%s'" % (i, data['status'], data['error']))
-					time.sleep(0.1)
-					continue
-			
-			# check to see if we have data
-			if data:
-				Debug("traktJsonRequest(): Have JSON data, breaking retry.")
-				break
-			
-		except ValueError:
-			Debug("traktJsonRequest(): (%i) Bad JSON response: '%s'", (i, raw))
-			if not silent:
-				notification("trakt", __language__(1109).encode( "utf-8", "ignore" ) + ": Bad response from trakt") # Error
-		except Exception:
-			import traceback
-			Debug("traktJsonRequest(): (%i) Unknown Exception: %s" % (i, traceback.format_exc()))
-
-		time.sleep(0.1)
-	
-	# handle scenario where all retries fail
-	if not data:
-		Debug("traktJsonRequest(): JSON Request failed, data is still empty after retries.")
-		return None
-	
-	if 'status' in data:
-		if data['status'] == 'failure':
-			Debug("traktJsonRequest(): Error: %s" % str(data['error']))
-			if returnStatus:
-				return data
-			if not silent:
-				notification("trakt", __language__(1109).encode( "utf-8", "ignore" ) + ": " + str(data['error'])) # Error
-			return None
-		elif data['status'] == 'success':
-			Debug("traktJsonRequest(): JSON request was successful.")
-
-	return data
 
 # get a single episode from xbmc given the id
 def getEpisodeDetailsFromXbmc(libraryId, fields):
@@ -367,70 +182,3 @@ def getPlaylistLengthFromXBMCPlayer(playerid):
 
 	return result['result']['size']
 
-###############################
-##### Scrobbling to trakt #####
-###############################
-
-#tell trakt that the user is watching a movie
-def watchingMovieOnTrakt(imdb_id, title, year, duration, percent):
-	Debug("watchingMovieOnTrakt(): Calling traktJsonRequest()")
-	response = traktJsonRequest('POST', '/movie/watching/%%API_KEY%%', {'imdb_id': imdb_id, 'title': title, 'year': year, 'duration': math.ceil(duration), 'progress': math.ceil(percent)}, passVersions=True)
-	Debug("watchingMovieOnTrakt(): traktJsonRequest() returned")
-	if response == None:
-		Debug("watchingMovieOnTrakt(): Error in request")
-	return response
-
-#tell trakt that the user is watching an episode
-def watchingEpisodeOnTrakt(tvdb_id, title, year, season, episode, uniqueid, duration, percent):
-	Debug("watchingEpisodeOnTrakt(): Calling traktJsonRequest()")
-	response = traktJsonRequest('POST', '/show/watching/%%API_KEY%%', {'tvdb_id': tvdb_id, 'title': title, 'year': year, 'season': season, 'episode': episode, 'episode_tvdb_id': uniqueid, 'duration': math.ceil(duration), 'progress': math.ceil(percent)}, passVersions=True)
-	Debug("watchingEpisodeOnTrakt(): traktJsonRequest() returned")
-	if response == None:
-		Debug("watchingEpisodeOnTrakt(): Error in request")
-	return response
-
-#tell trakt that the user has stopped watching a movie
-def cancelWatchingMovieOnTrakt():
-	Debug("cancelWatchingMovieOnTrakt(): Calling traktJsonRequest()")
-	response = traktJsonRequest('POST', '/movie/cancelwatching/%%API_KEY%%')
-	Debug("cancelWatchingMovieOnTrakt(): traktJsonRequest() returned")
-	if response == None:
-		Debug("cancelWatchingMovieOnTrakt(): Error in request")
-	return response
-
-#tell trakt that the user has stopped an episode
-def cancelWatchingEpisodeOnTrakt():
-	Debug("cancelWatchingEpisodeOnTrakt(): Calling traktJsonRequest()")
-	response = traktJsonRequest('POST', '/show/cancelwatching/%%API_KEY%%')
-	Debug("cancelWatchingEpisodeOnTrakt(): traktJsonRequest() returned")
-	if response == None:
-		Debug("cancelWatchingEpisodeOnTrakt(): Error in request")
-	return response
-
-#tell trakt that the user has finished watching an movie
-def scrobbleMovieOnTrakt(imdb_id, title, year, duration, percent):
-	Debug("scrobbleMovieOnTrakt(): Calling traktJsonRequest()")
-	response = traktJsonRequest('POST', '/movie/scrobble/%%API_KEY%%', {'imdb_id': imdb_id, 'title': title, 'year': year, 'duration': math.ceil(duration), 'progress': math.ceil(percent)}, passVersions=True)
-	Debug("scrobbleMovieOnTrakt(): traktJsonRequest() returned")
-	if response == None:
-		Debug("scrobbleMovieOnTrakt(): Error in request")
-	return response
-
-#tell trakt that the user has finished watching an episode
-def scrobbleEpisodeOnTrakt(tvdb_id, title, year, season, episode, uniqueid, duration, percent):
-	Debug("scrobbleEpisodeOnTrakt(): Calling traktJsonRequest()")
-	response = traktJsonRequest('POST', '/show/scrobble/%%API_KEY%%', {'tvdb_id': tvdb_id, 'title': title, 'year': year, 'season': season, 'episode': episode, 'episode_tvdb_id': uniqueid, 'duration': math.ceil(duration), 'progress': math.ceil(percent)}, passVersions=True)
-	Debug("scrobbleEpisodeOnTrakt(): traktJsonRequest() returned")
-	if response == None:
-		Debug("scrobbleEpisodeOnTrakt(): Error in request")
-	return response
-
-def getTraktSettings():
-	"""Get the users settings from trakt.tv"""
-	global traktSettings
-
-	response = traktJsonRequest('POST', '/account/settings/%%API_KEY%%', passVersions=True)
-	if response == None:
-		Debug("Error in request from 'getTraktSettings()'")
-
-	traktSettings = response


### PR DESCRIPTION
- Move all traktJsonRequest calls to a traktAPI class.
- Startup notification and scrobler irregardless.
- Test account every call, save state after first successful call.
- Increase urllib2.urlopen timeout to 60 seconds, from 10 seconds.  Reason for this, when checking the plugin for MediaPortal, it uses C# Webclient which has a default timeout of 100 seconds.
- Rewrite getData, and verify all error scenarios (used own host to verify).
- Make traktAPI a bit more chatty for debugging.
- Switch back to JSON username/password for authentication (either way works).
- With debug logging, add ability to hide sensitive data from log.
- Setup ability to possibly implement a queue based system for non-important calls.
- Other changes/additions i probably forgot about.

This needs a bit of testing before being merged (if it gets merged), just to make sure I didn't miss any merges, since I merged this in from my debugging folder.

I've been testing this code for the past 9 days (on my live HTPC box), and have gathered some statistics (which are pasted below).

Also, since increasing the timeout to 60 seconds, imo it seems to be a bit more stable, I haven't seen it do any retries.  Also, haven't seen any 503 errors, so that part of it hasn't been thoroughly tested (would it be possible to have a test api to emulate a 503 error?)

```
API calls made: 487
  Attempt 0: 487
Resposne time: min 355.00 ms, max 37206.00 ms, avg 2000.38 ms
  200: 487 (avg 2000.38 ms)
Methods:
  Method: account/settings (total 13, avg 1194.85 ms)
    Response 200: 13 (avg 1194.85 ms)
  Method: account/test (total 13, avg 7642.92 ms)
    Response 200: 13 (avg 7642.92 ms)
  Method: movie/library (total 1, avg 914.00 ms)
    Response 200: 1 (avg 914.00 ms)
  Method: movie/scrobble (total 2, avg 1885.00 ms)
    Response 200: 2 (avg 1885.00 ms)
  Method: movie/seen (total 8, avg 880.00 ms)
    Response 200: 8 (avg 880.00 ms)
  Method: movie/summary.json (total 2, avg 1687.00 ms)
    Response 200: 2 (avg 1687.00 ms)
  Method: movie/watching (total 19, avg 2000.11 ms)
    Response 200: 19 (avg 2000.11 ms)
  Method: rate/movie (total 1, avg 1541.00 ms)
    Response 200: 1 (avg 1541.00 ms)
  Method: show/cancelwatching (total 1, avg 1216.00 ms)
    Response 200: 1 (avg 1216.00 ms)
  Method: show/episode/library (total 38, avg 1744.63 ms)
    Response 200: 38 (avg 1744.63 ms)
  Method: show/episode/seen (total 11, avg 2016.27 ms)
    Response 200: 11 (avg 2016.27 ms)
  Method: show/scrobble (total 41, avg 2412.32 ms)
    Response 200: 41 (avg 2412.32 ms)
  Method: show/watching (total 294, avg 1848.51 ms)
    Response 200: 294 (avg 1848.51 ms)
  Method: user/library/movies/collection.json (total 12, avg 2253.67 ms)
    Response 200: 12 (avg 2253.67 ms)
  Method: user/library/movies/watched.json (total 11, avg 1295.36 ms)
    Response 200: 11 (avg 1295.36 ms)
  Method: user/library/shows/collection.json (total 10, avg 1592.00 ms)
    Response 200: 10 (avg 1592.00 ms)
  Method: user/library/shows/watched.json (total 10, avg 1538.30 ms)
    Response 200: 10 (avg 1538.30 ms)
```
