### PR TITLE
Check for extra data when type is unknown.

### DIFF
--- a/scrobbler.py
+++ b/scrobbler.py
@@ -160,7 +160,7 @@ class Scrobbler(threading.Thread):
 				match['showtitle'] = self.curVideoData['showtitle']
 				match['season'] = self.curVideoData['season']
 				match['episode'] = self.curVideoData['episode']
-				match['uniqueid'] = self.curVideoData['uniqueid']['unknown']
+				match['uniqueid'] = None
 			if match == None:
 				return
 			response = utilities.watchingEpisodeOnTrakt(match['tvdb_id'], match['showtitle'], match['year'], match['season'], match['episode'], match['uniqueid']['unknown'], self.totalTime/60, int(100*self.watchedTime/self.totalTime))


### PR DESCRIPTION
With the change to using the native python notifcation, certain data wasn't returned from a Player.GetItem JSON RPC call, so do some further checking when type returned is unknown.

By checking data available from xbmc.getInfoLabel():

If unkown type is really an episode, then season, episode number, showtitle and title should be available.
If unkown type is really a movie, then title and year should be available.

Pass this new data along in the dispatch, to behave how it use to with OnPlay from telnet.

I believe this should fix scrobbling for certain video plugins, when they provide data like this.

I don't use anything but the library, so I can't verify most of this, copies of OnPlay events from a telnet session when using these plugins would help in debugging if there are any errors.
