### PR TITLE
Fix object is unsubscriptable error

### DIFF
--- a/scrobbler.py
+++ b/scrobbler.py
@@ -125,10 +125,11 @@ class Scrobbler():
 					self.curVideoInfo = {}
 					self.curVideoInfo['tvdb_id'] = None
 					self.curVideoInfo['year'] = None
+					if 'year' in self.curVideo:
+						self.curVideoInfo['year'] = self.curVideo['year']
 					self.curVideoInfo['showtitle'] = self.curVideo['showtitle']
 					self.curVideoInfo['season'] = self.curVideo['season']
 					self.curVideoInfo['episode'] = self.curVideo['episode']
-					self.curVideoInfo['uniqueid'] = None
 
 				if 'multi_episode_count' in self.curVideo:
 					self.isMultiPartEpisode = True

--- a/service.py
+++ b/service.py
@@ -223,6 +223,8 @@ class traktPlayer(xbmc.Player):
 					data['episode'] = int(episode)
 					data['showtitle'] = showtitle
 					data['title'] = xbmc.getInfoLabel('VideoPlayer.Title')
+					if year.isdigit():
+						data['year'] = year
 					utilities.Debug("[traktPlayer] onPlayBackStarted() - Playing a non-library 'episode' - %s - S%02dE%02d - %s." % (data['showtitle'], data['season'], data['episode'], data['title']))
 				elif year and not season and not showtitle:
 					# we have a year and no season/showtitle info, enough for a movie

--- a/traktapi.py
+++ b/traktapi.py
@@ -325,7 +325,7 @@ class traktAPI(object):
 	def watchingEpisode(self, info, duration, percent):
 		data = {'tvdb_id': info['tvdb_id'], 'title': info['showtitle'], 'year': info['year'], 'season': info['season'], 'episode': info['episode'], 'duration': math.ceil(duration), 'progress': math.ceil(percent)}
 		if 'uniqueid' in info:
-			data['episode_tvdb_id'] = info['uniqueid']['unknown'], 
+			data['episode_tvdb_id'] = info['uniqueid']['unknown']
 		return self.watching('show', data)
 	def watchingMovie(self, info, duration, percent):
 		data = {'imdb_id': info['imdbnumber'], 'title': info['title'], 'year': info['year'], 'duration': math.ceil(duration), 'progress': math.ceil(percent)}

--- a/traktapi.py
+++ b/traktapi.py
@@ -323,7 +323,9 @@ class traktAPI(object):
 			return self.traktRequest('POST', url, data, passVersions=True)
 	
 	def watchingEpisode(self, info, duration, percent):
-		data = {'tvdb_id': info['tvdb_id'], 'title': info['showtitle'], 'year': info['year'], 'season': info['season'], 'episode': info['episode'], 'episode_tvdb_id': info['uniqueid']['unknown'], 'duration': math.ceil(duration), 'progress': math.ceil(percent)}
+		data = {'tvdb_id': info['tvdb_id'], 'title': info['showtitle'], 'year': info['year'], 'season': info['season'], 'episode': info['episode'], 'duration': math.ceil(duration), 'progress': math.ceil(percent)}
+		if 'uniqueid' in info:
+			data['episode_tvdb_id'] = info['uniqueid']['unknown'], 
 		return self.watching('show', data)
 	def watchingMovie(self, info, duration, percent):
 		data = {'imdb_id': info['imdbnumber'], 'title': info['title'], 'year': info['year'], 'duration': math.ceil(duration), 'progress': math.ceil(percent)}


### PR DESCRIPTION
Mis-handled uniqueid when type was non-library item, removed it, and added check in api function to add uniqueid to data passed if it exists in video info.
Check year of non-library item, if its digits, add it to the information.

Needs testing of course.

If anyone who uses the streaming plugins listed in the tested and scrobbling correctly (Amazon, CBS, southpark, PleXBMC) could get in contact with me on xbmc's IRC (freenode), I could debug this a lot quicker and solve once and for all hopefully.
