### PR TITLE
Fix crash in rating.

### DIFF
--- a/rating.py
+++ b/rating.py
@@ -24,9 +24,9 @@ def ratingCheck(media_type, summary_info, watched_time, total_time, playlist_len
 			else:
 				Debug("[Rating] Rate each playlist item is disabled.")
 		else:
-			Debug("[Rating] '%s' does not meet minimum view time for rating (watched: %0.2f%%, minimum: %0.2f%%)" % (current_video['type'], watched, utilities.getSettingAsFloat("rate_min_view_time")))
+			Debug("[Rating] '%s' does not meet minimum view time for rating (watched: %0.2f%%, minimum: %0.2f%%)" % (media_type, watched, utilities.getSettingAsFloat("rate_min_view_time")))
 	else:
-		Debug("[Rating] '%s' is configured to not be rated." % current_video['type'])
+		Debug("[Rating] '%s' is configured to not be rated." % media_type)
 
 def rateMedia(media_type, summary_info):
 	"""Launches the rating dialog"""


### PR DESCRIPTION
Forgot to rename 2 variables in rating update to support non-library items. This caused a crash when stopping a video.

Yes, I know, I'm opening to many pull requests. Still have a few more in the works.
