### PR TITLE
Dispatch queue

### DIFF
--- a/rating.py
+++ b/rating.py
@@ -13,20 +13,20 @@ __addon__ = xbmcaddon.Addon("script.trakt")
 def ratingCheck(media_type, summary_info, watched_time, total_time, playlist_length):
 	"""Check if a video should be rated and if so launches the rating dialog"""
 	Debug("[Rating] Rating Check called for '%s'" % media_type);
+	if not utilities.getSettingAsBool("rate_%s" % media_type):
+		Debug("[Rating] '%s' is configured to not be rated." % media_type)
+		return
 	if summary_info is None:
 		Debug("[Rating] Summary information is empty, aborting.")
 		return
-	if utilities.getSettingAsBool("rate_%s" % media_type):
-		watched = (watched_time / total_time) * 100
-		if watched >= utilities.getSettingAsFloat("rate_min_view_time"):
-			if (playlist_length <= 1) or utilities.getSettingAsBool("rate_each_playlist_item"):
-				rateMedia(media_type, summary_info)
-			else:
-				Debug("[Rating] Rate each playlist item is disabled.")
+	watched = (watched_time / total_time) * 100
+	if watched >= utilities.getSettingAsFloat("rate_min_view_time"):
+		if (playlist_length <= 1) or utilities.getSettingAsBool("rate_each_playlist_item"):
+			rateMedia(media_type, summary_info)
 		else:
-			Debug("[Rating] '%s' does not meet minimum view time for rating (watched: %0.2f%%, minimum: %0.2f%%)" % (media_type, watched, utilities.getSettingAsFloat("rate_min_view_time")))
+			Debug("[Rating] Rate each playlist item is disabled.")
 	else:
-		Debug("[Rating] '%s' is configured to not be rated." % media_type)
+		Debug("[Rating] '%s' does not meet minimum view time for rating (watched: %0.2f%%, minimum: %0.2f%%)" % (media_type, watched, utilities.getSettingAsFloat("rate_min_view_time")))
 
 def rateMedia(media_type, summary_info):
 	"""Launches the rating dialog"""

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -18,6 +18,7 @@
 	<string id="1041">Scrobble movies</string>
 	<string id="1042">Scrobble TV episodes</string>
 	<string id="1043">Minimum percent watched to scrobble</string>
+	<string id="1044">Simulate scrobbling (for testing purposes)</string>
 	
 	<string id="1050">Exclusions</string>
 	<string id="1051">Exclude Live TV</string>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,6 +10,7 @@
 	<category label="1040"><!-- Scrobbling -->
 		<setting id="scrobble_movie" type="bool" label="1041" default="true"/>
 		<setting id="scrobble_episode" type="bool" label="1042" default="true"/>
+		<setting id="simulate_scrobbling" type="bool" label="1044" default="false"/>
 		<setting id="scrobble_min_view_time" type="slider" label="1043" range="0,5,100" default="80"/>
 		<setting type="sep"/>
 		<setting label="1050" type="lsep"/><!--Exclusions -->

--- a/traktapi.py
+++ b/traktapi.py
@@ -325,7 +325,10 @@ class traktAPI(object):
 		if self.testAccount():
 			url = "%s/%s/watching/%s" % (self.__baseURL, type, self.__apikey)
 			Debug("[traktAPI] watching(url: %s, data: %s)" % (url, str(data)))
-			return self.traktRequest('POST', url, data, passVersions=True)
+			if getSettingAsBool('simulate_scrobbling'):
+				return {'status': 'success'}
+			else:
+				return self.traktRequest('POST', url, data, passVersions=True)
 	
 	def watchingEpisode(self, info, duration, percent):
 		data = {'tvdb_id': info['tvdb_id'], 'title': info['showtitle'], 'year': info['year'], 'season': info['season'], 'episode': info['episode'], 'duration': math.ceil(duration), 'progress': math.ceil(percent)}
@@ -342,7 +345,10 @@ class traktAPI(object):
 		if self.testAccount():
 			url = "%s/%s/scrobble/%s" % (self.__baseURL, type, self.__apikey)
 			Debug("[traktAPI] scrobble(url: %s, data: %s)" % (url, str(data)))
-			return self.traktRequest('POST', url, data, returnOnFailure=True, passVersions=True)
+			if getSettingAsBool('simulate_scrobbling'):
+				return {'status': 'success'}
+			else:
+				return self.traktRequest('POST', url, data, returnOnFailure=True, passVersions=True)
 
 	def scrobbleEpisode(self, info, duration, percent):
 		data = {'tvdb_id': info['tvdb_id'], 'title': info['showtitle'], 'year': info['year'], 'season': info['season'], 'episode': info['episode'], 'duration': math.ceil(duration), 'progress': math.ceil(percent)}
@@ -359,7 +365,10 @@ class traktAPI(object):
 		if self.testAccount():
 			url = "%s/%s/cancelwatching/%s" % (self.__baseURL, type, self.__apikey)
 			Debug("[traktAPI] cancelWatching(url: %s)" % url)
-			return self.traktRequest('POST', url)
+			if getSettingAsBool('simulate_scrobbling'):
+				return {'status': 'success'}
+			else:
+				return self.traktRequest('POST', url)
 		
 	def cancelWatchingEpisode(self):
 		return self.cancelWatching('show')


### PR DESCRIPTION
As per a post by codeseven in the trakt.tv plugin thread, here is a fix for issues with playlist scrobbling.

The main part of this is introducing a queue for the dispatch events, the primary reason for this is to help avoid possible race conditions with the player/monitor interfaces.

Issues with scrobbling from playlists should also be resolved with this fix.

Just like in the sync change, I've also added an option to simulate scrobbling to aid in testing.

As usual, please test and provide feedback.

Please do not merge just yet, still double checking a few things, and testing.  Also, going to get codeseven to test this to see if it resolves the issues, will comment again when its ready.

Changes are as follows:
- Add simulate scrobble setting for testing.
- Implement queue for dispatch events, should resolve race conditions that can occur.
- Dispatch queue is acted upon every cycle and cleared.
- Add check for xbmc playing video when doing update() from service thread.
- Remove old check for switching videos in a playlist in scrobbler class.
- Small change to rating check, perform the setting check before anything else.
- Change how updating time is handled, only update if the current playlist index is the same as what was seen when playback started.
- In traktPlayer, save playlist index in onPlayBackStarted to variable.
- In traktPlayer, onPlayBackStarted, check current playlist index to saved index if playlist length is greater then 1, if it is, fire an onPlayBackEnded event.
- Add some more debug lines to help in testing playlist playback.
