### PR TITLE
Fix for wrong data type of tmdb_id in watched movie data

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -441,6 +441,7 @@ class Sync():
 			if movie['tmdb_id'] is None:
 				movie['tmdb_id'] = ""
 		for movie in watched_movies:
+			movie['tmdb_id'] = unicode(movie['tmdb_id'])
 			m = self.findMovie(movie, movies)
 			if m:
 				m['plays'] = movie['plays']


### PR DESCRIPTION
Handle data type inconsistency from trakt.tv api calls, type cast tmdb_id to unicode when iterating over watched movie data.

This was causing an exception when building trakt movie list if there are more watched movies then collected movies.
