### PR TITLE
Add script function to trigger a manual rating.

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -4,7 +4,7 @@
 		<import addon="xbmc.python" version="2.1.0"/>
 		<import addon="script.module.simplejson" version="2.0.10"/>
 	</requires>
-	<extension point="xbmc.python.script" library="manual_sync.py">
+	<extension point="xbmc.python.script" library="script.py">
 		<provides>executable</provides>
 	</extension>
 	<extension point="xbmc.service" name="trakt.service" library="default.py" start="login" />

--- a/manual_sync.py
+++ b/manual_sync.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-
-import utilities as utils
-
-if __name__ == '__main__':
-
-	# set property for service to initiate a manual sync
-	utils.setProperty('traktManualSync', 'True')

--- a/rating.py
+++ b/rating.py
@@ -4,48 +4,90 @@
 import xbmc
 import xbmcaddon
 import xbmcgui
-import utilities
+import utilities as utils
 import globals
-from utilities import Debug, notification
 
 __addon__ = xbmcaddon.Addon("script.trakt")
 
 def ratingCheck(media_type, summary_info, watched_time, total_time, playlist_length):
 	"""Check if a video should be rated and if so launches the rating dialog"""
-	Debug("[Rating] Rating Check called for '%s'" % media_type);
-	if not utilities.getSettingAsBool("rate_%s" % media_type):
-		Debug("[Rating] '%s' is configured to not be rated." % media_type)
+	utils.Debug("[Rating] Rating Check called for '%s'" % media_type);
+	if not utils.getSettingAsBool("rate_%s" % media_type):
+		utils.Debug("[Rating] '%s' is configured to not be rated." % media_type)
 		return
 	if summary_info is None:
-		Debug("[Rating] Summary information is empty, aborting.")
+		utils.Debug("[Rating] Summary information is empty, aborting.")
 		return
 	watched = (watched_time / total_time) * 100
-	if watched >= utilities.getSettingAsFloat("rate_min_view_time"):
-		if (playlist_length <= 1) or utilities.getSettingAsBool("rate_each_playlist_item"):
+	if watched >= utils.getSettingAsFloat("rate_min_view_time"):
+		if (playlist_length <= 1) or utils.getSettingAsBool("rate_each_playlist_item"):
 			rateMedia(media_type, summary_info)
 		else:
-			Debug("[Rating] Rate each playlist item is disabled.")
+			utils.Debug("[Rating] Rate each playlist item is disabled.")
 	else:
-		Debug("[Rating] '%s' does not meet minimum view time for rating (watched: %0.2f%%, minimum: %0.2f%%)" % (media_type, watched, utilities.getSettingAsFloat("rate_min_view_time")))
+		utils.Debug("[Rating] '%s' does not meet minimum view time for rating (watched: %0.2f%%, minimum: %0.2f%%)" % (media_type, watched, utils.getSettingAsFloat("rate_min_view_time")))
 
-def rateMedia(media_type, summary_info):
+def rateMedia(media_type, summary_info, unrate=False, rating=None):
 	"""Launches the rating dialog"""
-	if utilities.isMovie(media_type):
-		if summary_info['rating'] or summary_info['rating_advanced']:
-			Debug("[Rating] Movie has already been rated.")
-			return
-
-	elif utilities.isEpisode(media_type):
-		if summary_info['episode']['rating'] or summary_info['episode']['rating_advanced']:
-			Debug("[Rating] Episode has already been rated.")
-			return
-
-	else:
+	if not utils.isValidMediaType(media_type):
 		return
+	
+	if utils.isEpisode(media_type):
+		if 'rating' in summary_info['episode']:
+			summary_info['rating'] = summary_info['episode']['rating']
+		if 'rating_advanced' in summary_info['episode']:
+			summary_info['rating_advanced'] = summary_info['episode']['rating_advanced']
+
+	s = utils.getFormattedItemName(media_type, summary_info)
 
 	if not globals.traktapi.settings:
 		globals.traktapi.getAccountSettings()
 	rating_type = globals.traktapi.settings['viewing']['ratings']['mode']
+
+	if unrate:
+		rating = None
+
+		if rating_type == "simple":
+			if not summary_info['rating'] == "false":
+				rating = "unrate"
+		else:
+			if summary_info['rating_advanced'] > 0:
+				rating = 0
+
+		if not rating is None:
+			utils.Debug("[Rating] '%s' is being unrated." % s)
+			rateOnTrakt(rating, media_type, summary_info, unrate=True)
+		else:
+			utils.Debug("[Rating] '%s' has not been rated, so not unrating." % s)
+
+		return
+
+	rerate = utils.getSettingAsBool('rate_rerate')
+	if not rating is None:
+		if summary_info['rating_advanced'] == 0:
+			utils.Debug("[Rating] Rating for '%s' is being set to '%d' manually." % (s, rating))
+			rateOnTrakt(rating, media_type, summary_info)
+		else:
+			if rerate:
+				if not summary_info['rating_advanced'] == rating:
+					utils.Debug("[Rating] Rating for '%s' is being set to '%d' manually." % (s, rating))
+					rateOnTrakt(rating, media_type, summary_info)
+				else:
+					utils.notification(s, utils.getString(1170) % utils.getFormattedType(media_type))
+					utils.Debug("[Rating] '%s' already has a rating of '%d'." % (s, rating))
+			else:
+				utils.notification(s, utils.getString(1168) % utils.getFormattedType(media_type))
+				utils.Debug("[Rating] '%s' is already rated." % s)
+		return
+
+	if summary_info['rating'] or summary_info['rating_advanced']:
+		if not rerate:
+			utils.Debug("[Rating] '%s' has already been rated." % s)
+			utils.notification(s, utils.getString(1168) % utils.getFormattedType(media_type))
+			return
+		else:
+			utils.Debug("[Rating] '%s' is being re-rated." % s)
+	
 	xbmc.executebuiltin('Dialog.Close(all, true)')
 
 	gui = RatingDialog(
@@ -53,33 +95,59 @@ def rateMedia(media_type, summary_info):
 		__addon__.getAddonInfo('path'),
 		media_type=media_type,
 		media=summary_info,
-		rating_type=rating_type
+		rating_type=rating_type,
+		rerate=rerate
 	)
 
 	gui.doModal()
 	if gui.rating:
-		rateOnTrakt(gui.rating, gui.media_type, gui.media)
+		rating = gui.rating
+		if rerate:
+			rating = gui.rating
+			
+			if rating_type == "simple":
+				if not summary_info['rating'] == "false" and rating == summary_info['rating']:
+					rating = "unrate"
+			else:
+				if summary_info['rating_advanced'] > 0 and rating == summary_info['rating_advanced']:
+					rating = 0
+
+		if rating == 0 or rating == "unrate":
+			rateOnTrakt(rating, gui.media_type, gui.media, unrate=True)
+		else:
+			rateOnTrakt(rating, gui.media_type, gui.media)
+	else:
+		utils.Debug("[Rating] Rating dialog was closed with no rating.")
+
 	del gui
 
-def rateOnTrakt(rating, media_type, media):
-	Debug("[Rating] Sending rating (%s) to trakt.tv" % rating)
-	if utilities.isMovie(media_type):
-		params = {}
+def rateOnTrakt(rating, media_type, media, unrate=False):
+	utils.Debug("[Rating] Sending rating (%s) to trakt.tv" % rating)
+
+	params = {}
+	params['rating'] = rating
+
+	if utils.isMovie(media_type):
 		params['title'] = media['title']
 		params['year'] = media['year']
-		params['rating'] = rating
 		params['tmdb_id'] = media['tmdb_id']
 		params['imdb_id'] = media['imdb_id']
 
 		data = globals.traktapi.rateMovie(params)
 
-	elif utilities.isEpisode(media_type):
-		params = {}
+	elif utils.isShow(media_type):
+		params['title'] = media['title']
+		params['year'] = media['year']
+		params['tvdb_id'] = media['tvdb_id']
+		params['imdb_id'] = media['imdb_id']
+
+		data = globals.traktapi.rateShow(params)
+	
+	elif utils.isEpisode(media_type):
 		params['title'] = media['show']['title']
 		params['year'] = media['show']['year']
 		params['season'] = media['episode']['season']
 		params['episode'] = media['episode']['number']
-		params['rating'] = rating
 		params['tvdb_id'] = media['show']['tvdb_id']
 		params['imdb_id'] = media['show']['imdb_id']
 
@@ -89,22 +157,26 @@ def rateOnTrakt(rating, media_type, media):
 		return
 
 	if data != None:
-		notification(utilities.getString(1201), utilities.getString(1167)) # Rating submitted successfully
+		s = utils.getFormattedItemName(media_type, media)
+		if not unrate:
+			utils.notification(s, utils.getString(1167) % utils.getFormattedType(media_type))
+		else:
+			utils.notification(s, utils.getString(1169) % utils.getFormattedType(media_type))
 
 class RatingDialog(xbmcgui.WindowXMLDialog):
 	buttons = {
 		10030:	'love',
 		10031:	'hate',
-		11030:	'1',
-		11031:	'2',
-		11032:	'3',
-		11033:	'4',
-		11034:	'5',
-		11035:	'6',
-		11036:	'7',
-		11037:	'8',
-		11038:	'9',
-		11039:	'10'
+		11030:	1,
+		11031:	2,
+		11032:	3,
+		11033:	4,
+		11034:	5,
+		11035:	6,
+		11036:	7,
+		11037:	8,
+		11038:	9,
+		11039:	10
 	}
 
 	focus_labels = {
@@ -122,25 +194,31 @@ class RatingDialog(xbmcgui.WindowXMLDialog):
 		11039: 1314
 	}
 
-	def __init__(self, xmlFile, resourcePath, forceFallback=False, media_type=None, media=None, rating_type=None):
+	def __init__(self, xmlFile, resourcePath, forceFallback=False, media_type=None, media=None, rating_type=None, rerate=False):
 		self.media_type = media_type
 		self.media = media
 		self.rating_type = rating_type
 		self.rating = None
+		self.rerate = rerate
 
 	def onInit(self):
 		self.getControl(10014).setVisible(self.rating_type == 'simple')
 		self.getControl(10015).setVisible(self.rating_type == 'advanced')
 
-		if self.media_type == 'movie':
-			self.getControl(10012).setLabel('%s (%s)' % (self.media['title'], self.media['year']))
-		else:
-			self.getControl(10012).setLabel('%s - %s' % (self.media['show']['title'], self.media['episode']['title']))
+		s = utils.getFormattedItemName(self.media_type, self.media, short=True)
+		self.getControl(10012).setLabel(s)
 
+		rateID = None
 		if self.rating_type == 'simple':
-			self.setFocus(self.getControl(10030)) #Focus Loved Button
+			rateID = 10030
+			if self.rerate:
+				if self.media['rating'] == "hate":
+					rateID = 10031
 		else:
-			self.setFocus(self.getControl(11037)) #Focus 8 Button
+			rateID = 11037
+			if self.rerate and int(self.media['rating_advanced']) > 0:
+				rateID = 11029 + int(self.media['rating_advanced'])
+		self.setFocus(self.getControl(rateID))
 
 	def onClick(self, controlID):
 		if controlID in self.buttons:
@@ -149,6 +227,18 @@ class RatingDialog(xbmcgui.WindowXMLDialog):
 
 	def onFocus(self, controlID):
 		if controlID in self.focus_labels:
-			self.getControl(10013).setLabel(utilities.getString(self.focus_labels[controlID]))
+			s = utils.getString(self.focus_labels[controlID])
+			if self.rerate:
+				if self.media['rating'] == self.buttons[controlID] or self.media['rating_advanced'] == self.buttons[controlID]:
+					if utils.isMovie(self.media_type):
+						s = utils.getString(1325)
+					elif utils.isShow(self.media_type):
+						s = utils.getString(1326)
+					elif utils.isEpisode(self.media_type):
+						s = utils.getString(1327)
+					else:
+						pass
+			
+			self.getControl(10013).setLabel(s)
 		else:
 			self.getControl(10013).setLabel('')

--- a/resources/language/Dutch/string.xml
+++ b/resources/language/Dutch/string.xml
@@ -79,7 +79,7 @@
 	<string id="1163">Ontvangen van informatie van Trakt servers</string>
 	<string id="1164">Doorverwijzing met lokale informatie</string>
 	<string id="1166">Beoordeling met succes verwijderd</string>
-	<string id="1167">Waardering met succes toegevoegd</string>
+	<string id="1167">Waardering voor '%s' werd toegevoegd</string>
 	<string id="1168">Fout bij het toevoegen van waardering</string>
 	<string id="1300">Controle van XBMC Database voor nieuwe bekeken films</string>
 	<string id="1301">Controle Trakt Database voor nieuwe bekeken films</string>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -13,6 +13,7 @@
 	<string id="1032">Rate TV Show Episode after watching</string>
 	<string id="1033">Rate each playlist item</string>
 	<string id="1034">Minimum percent watched to display rate dialog</string>
+	<string id="1035">Allow re-rating of media</string>
 	
 	<string id="1040">Scrobbling</string>
 	<string id="1041">Scrobble movies</string>
@@ -32,7 +33,10 @@
 	<string id="1108">Can't connect to trakt</string>
 	<string id="1109">Error</string>
 	<string id="1110">Incorrect username or password</string>
-	<string id="1167">Rating submitted successfully</string>
+	<string id="1167">Rating for %s was successfully submitted</string>
+	<string id="1168">%s has already been rated</string>
+	<string id="1169">%s successfully unrated</string>
+	<string id="1170">%s already has the same rating</string>
 	<string id="1313">What Did You Think?</string>
 	<string id="1314">Totally Ninja!</string>
 	<string id="1315">Weak Sauce :(</string>
@@ -44,9 +48,17 @@
 	<string id="1321">Good</string>
 	<string id="1322">Great</string>
 	<string id="1323">Superb</string>
+	<string id="1325">Unrate this movie</string>
+	<string id="1326">Unrate this show</string>
+	<string id="1327">Unrate this episode</string>
 
 	<!-- Titles -->
 	<string id="1201">trakt</string>
+	<string id="1202">trakt.tv Rating</string>
+	<string id="1205">Movie</string>
+	<string id="1206">TV Show</string>
+	<string id="1207">Season</string>
+	<string id="1208">Episode</string>
 	
 	<!-- Sync Settings -->
 	<string id="1400">Synchronize</string>

--- a/resources/language/Polish/strings.xml
+++ b/resources/language/Polish/strings.xml
@@ -77,7 +77,7 @@
 	<string id="1162">nie znaleziony w Twojej bibliotece XBMC</string>
 	<string id="1163">Pobieram informacje z serwerów Trakt</string>
 	<string id="1166">Ocena usunięta pomyślnie</string>
-	<string id="1167">Ocena wysłana pomyślnie</string>
+	<string id="1167">Ocena dla '%s' został wysłany pomyślnie</string>
 	<string id="1168">Błąd wysyłania oceny</string>
 	<string id="1180">rozpocznij aktualizację kolekcji filmów</string>
 	<string id="1181">rozpocznij aktualizację kolekcji seriali tv</string>

--- a/resources/language/Portuguese (Brazil)/strings.xml
+++ b/resources/language/Portuguese (Brazil)/strings.xml
@@ -32,7 +32,7 @@
 	<string id="1108">não foi possível conectar ao Trakt</string>
 	<string id="1109">Erro</string>
 	<string id="1110">Usuário ou senha incorretos</string>
-	<string id="1167">Avaliação enviada com sucesso</string>
+	<string id="1167">Avaliação para '%s' foi enviada com sucesso</string>
 	<string id="1313">O que voce achou?</string>
 	<string id="1314">Excepcional!</string>
 	<string id="1315">Péssimo!</string>

--- a/resources/language/Spanish/strings.xml
+++ b/resources/language/Spanish/strings.xml
@@ -32,7 +32,7 @@
 	<string id="1108">Imposible connectarse a Trakt</string>
 	<string id="1109">Error</string>
 	<string id="1110">Imposible connectarse a Trakt</string>
-	<string id="1167">Valoración enviada correctamente</string>
+	<string id="1167">Valoración para '%s' se ha enviada correctamente</string>
 	<string id="1313">¿Qué te pareció?</string>
 	<string id="1314">Totally Ninja!</string>
 	<string id="1315">Weak Sauce :(</string>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -46,5 +46,6 @@
 		<setting id="rate_episode" type="bool" label="1032" default="true"/>
 		<setting id="rate_each_playlist_item" type="bool" label="1033" default="true"/>
 		<setting id="rate_min_view_time" type="slider" label="1034" range="0,5,100" default="75"/>
+		<setting id="rate_rerate" type="bool" label="1035" default="false"/>
 	</category>
 </settings>

--- a/script.py
+++ b/script.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+import utilities as utils
+import xbmc
+import sys
+
+try:
+	import simplejson as json
+except ImportError:
+	import json
+
+def getMediaType():
+	
+	if xbmc.getCondVisibility('Container.Content(tvshows)'):
+		return "show"
+	elif xbmc.getCondVisibility('Container.Content(seasons)'):
+		return "season"
+	elif xbmc.getCondVisibility('Container.Content(episodes)'):
+		return "episode"
+	elif xbmc.getCondVisibility('Container.Content(movies)'):
+		return "movie"
+	else:
+		return None
+
+def getArguments():
+	data = None
+	
+	if len(sys.argv) == 1:
+		data = {'action': "sync"}
+	else:
+		data = {}
+		for item in sys.argv:
+			values = item.split("=")
+			if len(values) == 2:
+				data[values[0].lower()] = values[1].lower()
+
+	return data
+
+def Main():
+
+	args = getArguments()
+
+	if args['action'] == 'sync':
+		# set property for service to initiate a manual sync
+		utils.setProperty('traktManualSync', 'True')
+	elif args['action'] in ['rate', 'unrate']:
+		utils.Debug(str(args))
+		data = {}
+		data['action'] = args['action']
+		media_type = None
+		if 'media_type' in args and 'dbid' in args:
+			media_type = args['media_type']
+			try:
+				data['dbid'] = int(args['dbid'])
+			except ValueError:
+				utils.Debug("Manual %s triggered for library item, but DBID is invalid." % args['action'])
+				return
+		elif 'media_type' in args and 'remoteid' in args:
+			media_type = args['media_type']
+			data['remoteid'] = args['remoteid']
+			if 'season' in args:
+				if not 'episode' in args:
+					utils.Debug("Manual %s triggered for non-library episode, but missing episode number." % args['action'])
+					return
+				try:
+					data['season'] = int(args['season'])
+					data['episode'] = int(args['episode'])
+				except ValueError:
+					utilities.Debug("Error parsing season or episode for manual %s" % args['action'])
+					return
+		else:
+			media_type = getMediaType()
+			if not utils.isValidMediaType(media_type):
+				utils.Debug("Error, not in video library.")
+				return
+			data['dbid'] = int(xbmc.getInfoLabel('ListItem.DBID'))
+
+		if media_type is None:
+			utils.Debug("Manual %s triggered on an unsupported content container." % args['action'])
+		elif utils.isValidMediaType(media_type):
+			data['media_type'] = media_type
+			if 'dbid' in data:
+				utils.Debug("Manual %s of library '%s' with an ID of '%s'." % (args['action'], media_type, data['dbid']))
+			else:
+				if 'season' in data:
+					utils.Debug("Manual %s of non-library '%s' S%02dE%02d, with an ID of '%s'." % (args['action'], media_type, data['season'], data['episode'], data['remoteid']))
+				else:
+					utils.Debug("Manual %s of non-library '%s' with an ID of '%s'." % (args['action'], media_type, data['remoteid']))
+			if args['action'] == 'rate' and 'rating' in args:
+				if args['rating'] in ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']:
+					data['rating'] = int(args['rating'])
+			utils.setProperty('traktManualRateData', json.dumps(data))
+			utils.setProperty('traktManualRate', 'True')
+		else:
+			utils.Debug("Manual %s of '%s' is unsupported." % (args['action'], media_type))
+
+if __name__ == '__main__':
+	Main()

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -128,7 +128,7 @@ class Scrobbler():
 					self.curVideoInfo = utilities.getEpisodeDetailsFromXbmc(self.curVideo['id'], ['showtitle', 'season', 'episode', 'tvshowid', 'uniqueid'])
 					if utilities.getSettingAsBool('rate_episode'):
 						# pre-get sumamry information, for faster rating dialog.
-						self.traktSummaryInfo = self.traktapi.getShowSummary(self.curVideoInfo['tvdb_id'], self.curVideoInfo['season'], self.curVideoInfo['episode'])
+						self.traktSummaryInfo = self.traktapi.getEpisodeSummary(self.curVideoInfo['tvdb_id'], self.curVideoInfo['season'], self.curVideoInfo['episode'])
 				elif 'showtitle' in self.curVideo and 'season' in self.curVideo and 'episode' in self.curVideo:
 					self.curVideoInfo = {}
 					self.curVideoInfo['tvdb_id'] = None
@@ -246,7 +246,7 @@ class Scrobbler():
 							self.curVideoInfo['tvdb_id'] = response['show']['tvdb_id']
 							# get summary data now if we are rating this episode
 							if utilities.getSettingAsBool('rate_episode') and self.traktSummaryInfo is None:
-								self.traktSummaryInfo = self.traktapi.getShowSummary(self.curVideoInfo['tvdb_id'], self.curVideoInfo['season'], self.curVideoInfo['episode'])
+								self.traktSummaryInfo = self.traktapi.getEpisodeSummary(self.curVideoInfo['tvdb_id'], self.curVideoInfo['season'], self.curVideoInfo['episode'])
 
 				Debug("[Scrobbler] Watch response: %s" % str(response))
 

--- a/traktapi.py
+++ b/traktapi.py
@@ -209,10 +209,12 @@ class traktAPI(object):
 				elif returnOnFailure and data['status'] == 'failure':
 					Debug("[traktAPI] traktRequest(): Return on error set, breaking retry.")
 					break
-				else:
+				elif 'error' in data and data['status'] == 'failure':
 					Debug("[traktAPI] traktRequest(): (%i) JSON Error '%s' -> '%s'" % (i, data['status'], data['error']))
 					xbmc.sleep(1000)
 					continue
+				else:
+					pass
 
 			# check to see if we have data, an empty array is still valid data, so check for None only
 			if not data is None:
@@ -448,22 +450,25 @@ class traktAPI(object):
 	def updateSeenMovie(self, data):
 		return self.updateSeenInLibrary('movie', data)
 
-	# url: http://api.trakt.tv/<show/episode|movie>/summary.format/apikey/title[/season/episode]
-	# returns: returns information for a movie or episode
+	# url: http://api.trakt.tv/<show|show/episode|movie>/summary.format/apikey/title[/season/episode]
+	# returns: returns information for a movie, show or episode
 	def getSummary(self, type, data):
 		if self.testAccount():
 			url = "%s/%s/summary.json/%s/%s" % (self.__baseURL, type, self.__apikey, data)
 			Debug("[traktAPI] getSummary(url: %s)" % url)
 			return self.traktRequest('POST', url)
 
-	def getShowSummary(self, id, season, episode):
+	def getShowSummary(self, id):
+		data = str(id)
+		return self.getSummary('show', data)
+	def getEpisodeSummary(self, id, season, episode):
 		data = "%s/%s/%s" % (id, season, episode)
 		return self.getSummary('show/episode', data)
 	def getMovieSummary(self, id):
 		data = str(id)
 		return self.getSummary('movie', data)
 
-	# url: http://api.trakt.tv/rate/<episode|movie>/apikey
+	# url: http://api.trakt.tv/rate/<show|episode|movie>/apikey
 	# returns: {"status":"success","message":"rated Portlandia 1x01","type":"episode","rating":"love","ratings":{"percentage":100,"votes":2,"loved":2,"hated":0},"facebook":true,"twitter":true,"tumblr":false}
 	def rate(self, type, data):
 		if self.testAccount():
@@ -471,6 +476,8 @@ class traktAPI(object):
 			Debug("[traktAPI] rate(url: %s, data: %s)" % (url, str(data)))
 			return self.traktRequest('POST', url, data, passVersions=True)
 
+	def rateShow(self, data):
+		return self.rate('show', data)
 	def rateEpisode(self, data):
 		return self.rate('episode', data)
 	def rateMovie(self, data):

--- a/utilities.py
+++ b/utilities.py
@@ -67,6 +67,15 @@ def isMovie(type):
 def isEpisode(type):
 	return type == 'episode'
 
+def isShow(type):
+	return type == 'show'
+
+def isSeason(type):
+	return type == 'season'
+
+def isValidMediaType(type):
+	return type in ['movie', 'show', 'episode']
+
 def xbmcJsonRequest(params):
 	data = json.dumps(params)
 	request = xbmc.executeJSONRPC(data)
@@ -125,6 +134,43 @@ def checkScrobblingExclusion(fullpath):
 	
 	return False
 
+def getFormattedType(type):
+	if isMovie(type):
+		return getString(1205)
+	elif isShow(type):
+		return getString(1206)
+	elif isSeason(type):
+		return getString(1207)
+	elif isEpisode(type):
+		return getString(1208)
+
+def getFormattedItemName(type, info, short=False):
+	s = None
+	if isShow(type):
+		s = info['title']
+	elif isEpisode(type):
+		if short:
+			s = "S%02dE%02d - %s" % (info['episode']['season'], info['episode']['number'], info['episode']['title'])
+		else:
+			s = "%s - S%02dE%02d - %s" % (info['show']['title'], info['episode']['season'], info['episode']['number'], info['episode']['title'])
+	elif isMovie(type):
+		s = "%s (%s)" % (info['title'], info['year'])
+	return s
+
+def getShowDetailsFromXBMC(showID, fields):
+	result = xbmcJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShowDetails', 'params':{'tvshowid': showID, 'properties': ['year', 'imdbnumber']}, 'id': 1})
+	Debug("getShowDetailsFromXBMC(): %s" % str(result))
+
+	if not result:
+		Debug("getEpisodeDetailsFromXbmc(): Result from XBMC was empty.")
+		return None
+
+	try:
+		return result['tvshowdetails']
+	except KeyError:
+		Debug("getShowDetailsFromXBMC(): KeyError: result['tvshowdetails']")
+		return None
+
 # get a single episode from xbmc given the id
 def getEpisodeDetailsFromXbmc(libraryId, fields):
 	result = xbmcJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodeDetails', 'params':{'episodeid': libraryId, 'properties': fields}, 'id': 1})
@@ -134,15 +180,16 @@ def getEpisodeDetailsFromXbmc(libraryId, fields):
 		Debug("getEpisodeDetailsFromXbmc(): Result from XBMC was empty.")
 		return None
 
+	show_data = getShowDetailsFromXBMC(result['episodedetails']['tvshowid'], ['year', 'imdbnumber'])
+	
+	if not show_data:
+		Debug("getEpisodeDetailsFromXbmc(): Result from getShowDetailsFromXBMC() was empty.")
+		return None
+		
+	result['episodedetails']['tvdb_id'] = show_data['imdbnumber']
+	result['episodedetails']['year'] = show_data['year']
+	
 	try:
-		# get tvdb id
-		result_show = xbmcJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShowDetails', 'params':{'tvshowid': result['episodedetails']['tvshowid'], 'properties': ['year', 'imdbnumber']}, 'id': 1})
-		Debug("getEpisodeDetailsFromXbmc(): %s" % str(result_show))
-
-		# add to episode data
-		result['episodedetails']['tvdb_id'] = result_show['tvshowdetails']['imdbnumber']
-		result['episodedetails']['year'] = result_show['tvshowdetails']['year']
-
 		return result['episodedetails']
 	except KeyError:
 		Debug("getEpisodeDetailsFromXbmc(): KeyError: result['episodedetails']")


### PR DESCRIPTION
Added the ability to trigger a manual rating.
## Supported methods:

To rate the currently selected item:

```
RunScript(script.trakt,action=rate)
```

To rate a specific item:

```
RunScript(script.trakt,action=rate,media_type=<show|episode|movie>,dbid=#)
```
## Information

Rating the currently selected item **only** works in the various video library views, so either Movies, or TV Shows.

Manual rating only works with library items, it will not work with non-library items and there is no plans to add this support.

The best way to do this is to add a custom mapping `RunScript(script.trakt,action=rate)` to your keyboard.xml.  For example, in testing, I used the key V to trigger a manual rate.

I needed to make a change to the traktRequest call to support manual rating of tv shows, so this needs testing to make sure every other function still works.  Of course, feedback is welcome.

I also had to update the language translation of string 1167, I probably got it completely wrong, but they needed %s in them for the changes to rating submission being more descriptive, otherwise it would crash.  If I got it wrong, please just add a comment and I'll update them.

Lots of stuff done/moved/change, hoping I covered everything.
## Changes:
- Rename manual_sync.py to script.py
- Add a script function to trigger a manual rating from either a keypress association, or from within a skin.
- Can manually rate a movie, base tv show, or episode.
- Use, RunScript(script.trakt,action=rate) to trigger a manual rating.
- Check the type of media currently selected based on the currently visible container  (movie, tvshow, season, episode).
- Allow overriding the media_type and ID for manual rating.
- Add error checking when getting data from XBMC
- Add setting to allow re-rating of media.
- Signal service thread with type of media and DB id of currently selected item to perform a manual rating.
- Add signaling check in service thread for manual rating.
- Clear properties used when calling manual functions, as to not re-trigger them if service crashes before clearing properties.
- Add isShow, getShowDetailsFromXBMC and isValidMediaType helper functions.
- Add supporting calls to traktapi class.
- Alter check for status/error fields in traktRequest, since show summary has a status field which is not success/failure, this caused an error.
- Rename getShowSummary to getEpisodeSummary
- Rename getTVShowSummary to getShowSummary
- Add season/episode to rating dialog, now shows <Show> - S##E## - <Episode Title>.
- If media is already rated, and re-rating is not enabled, always show notification, even on a rate after a scrobble.
- Add ability to show notification that a show/episode/movie has already been rated.
- Make already rated notification more descriptive
- Make rating submission notification more descriptive
- Add new notification header string for ratings
- If re-rating media, set current rating as focus on dialog.
- Updated all translations of string 1167, they're probably wrong, but without %s would have caused a crash.
