### PR TITLE
Add function to ToggleWatched

### DIFF
--- a/queue.py
+++ b/queue.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+
+import os
+import sqlite3
+import utilities as utils
+
+try:
+	from simplejson import loads, dumps
+except ImportError:
+	from json import loads, dumps
+from time import sleep
+
+try:
+	from thread import get_ident
+except ImportError:
+	from dummy_thread import get_ident
+
+import xbmc
+import xbmcvfs
+import xbmcaddon
+
+__addon__ = xbmcaddon.Addon('script.trakt')
+
+# code from http://flask.pocoo.org/snippets/88/ with some modifications
+class SqliteQueue(object):
+
+	_create = (
+				'CREATE TABLE IF NOT EXISTS queue ' 
+				'('
+				'  id INTEGER PRIMARY KEY AUTOINCREMENT,'
+				'  item BLOB'
+				')'
+				)
+	_count = 'SELECT COUNT(*) FROM queue'
+	_iterate = 'SELECT id, item FROM queue'
+	_append = 'INSERT INTO queue (item) VALUES (?)'
+	_write_lock = 'BEGIN IMMEDIATE'
+	_get = (
+			'SELECT id, item FROM queue '
+			'ORDER BY id LIMIT 1'
+			)
+	_del = 'DELETE FROM queue WHERE id = ?'
+	_peek = (
+			'SELECT item FROM queue '
+			'ORDER BY id LIMIT 1'
+			)
+	_purge = 'DELETE FROM queue'
+
+	def __init__(self):
+		self.path = xbmc.translatePath(__addon__.getAddonInfo("profile")).decode("utf-8")
+		if not xbmcvfs.exists(self.path):
+			utils.Debug("Making path structure: " + repr(self.path))
+			xbmcvfs.mkdir(self.path)
+		self.path = os.path.join(self.path, 'queue.db')
+		self._connection_cache = {}
+		with self._get_conn() as conn:
+			conn.execute(self._create)
+
+	def __len__(self):
+		with self._get_conn() as conn:
+			l = conn.execute(self._count).next()[0]
+		return l
+
+	def __iter__(self):
+		with self._get_conn() as conn:
+			for id, obj_buffer in conn.execute(self._iterate):
+				yield loads(str(obj_buffer))
+
+	def _get_conn(self):
+		id = get_ident()
+		if id not in self._connection_cache:
+			self._connection_cache[id] = sqlite3.Connection(self.path, timeout=60)
+		return self._connection_cache[id]
+
+	def purge(self):
+		with self._get_conn() as conn:
+			conn.execute(self._purge)
+
+	def append(self, obj):
+		obj_buffer = dumps(obj)
+		with self._get_conn() as conn:
+			conn.execute(self._append, (obj_buffer,)) 
+
+	def get(self, sleep_wait=True):
+		keep_pooling = True
+		wait = 0.1
+		max_wait = 2
+		tries = 0
+		with self._get_conn() as conn:
+			id = None
+			while keep_pooling:
+				conn.execute(self._write_lock)
+				cursor = conn.execute(self._get)
+				try:
+					id, obj_buffer = cursor.next()
+					keep_pooling = False
+				except StopIteration:
+					conn.commit() # unlock the database
+					if not sleep_wait:
+						keep_pooling = False
+						continue
+					tries += 1
+					sleep(wait)
+					wait = min(max_wait, tries/10 + wait)
+			if id:
+				conn.execute(self._del, (id,))
+				return loads(str(obj_buffer))
+		return None
+
+	def peek(self):
+		with self._get_conn() as conn:
+			cursor = conn.execute(self._peek)
+			try:
+				return loads(str(cursor.next()[0]))
+			except StopIteration:
+				return None

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -74,6 +74,7 @@
 	<string id="1412">Show notifications</string>
 	<string id="1413">Clean trakt movie collection</string>
 	<string id="1414">Clean trakt episode collection</string>
+	<string id="1416">Show marked as watched notification</string>
 
 	<!-- Sync Notifications -->
 	<string id="1420">Sync started</string>
@@ -156,6 +157,11 @@
 
 	<!-- Sync Episodes - complete -->
 	<string id="1442">Episode Sync Complete</string>
+
+	<!-- Sync - manual mark watched -->
+	<string id="1550">trakt.tv - Marked as watched</string>
+	<string id="1551">trakt.tv - Failed making as watched</string>
+	<string id="1552">%d episode(s) of '%s'</string>
 
 	<!-- Debug Settings -->
 	<string id="1700">Debug</string>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -25,6 +25,7 @@
 		<setting label="1410" type="lsep"/><!-- Service -->
 		<setting id="sync_on_update" type="bool" label="1411" default="false"/>
 		<setting id="show_sync_notifications" type="bool" label="1412" default="false"/>
+		<setting id="show_marked_notification" type="bool" label="1416" default="true"/>
 		<setting type="sep"/>
 		<setting label="1402" type="lsep"/><!-- Movies -->
 		<setting id="add_movies_to_trakt" type="bool" label="1403" default="true"/>

--- a/script.py
+++ b/script.py
@@ -3,6 +3,7 @@
 import utilities as utils
 import xbmc
 import sys
+import queue
 
 try:
 	import simplejson as json
@@ -39,12 +40,12 @@ def getArguments():
 def Main():
 
 	args = getArguments()
+	data = {}
 
 	if args['action'] == 'sync':
-		# set property for service to initiate a manual sync
-		utils.setProperty('traktManualSync', 'True')
+		data = {'action': 'manualSync'}
+
 	elif args['action'] in ['rate', 'unrate']:
-		utils.Debug(str(args))
 		data = {}
 		data['action'] = args['action']
 		media_type = None
@@ -81,18 +82,154 @@ def Main():
 			data['media_type'] = media_type
 			if 'dbid' in data:
 				utils.Debug("Manual %s of library '%s' with an ID of '%s'." % (args['action'], media_type, data['dbid']))
+				if utils.isMovie(media_type):
+					result = utils.getMovieDetailsFromXbmc(data['dbid'], ['imdbnumber', 'title', 'year'])
+					if not result:
+						utils.Debug("No data was returned from XBMC, aborting manual %s." % args['action'])
+						return
+					data['imdbnumber'] = result['imdbnumber']
+
+				elif utils.isShow(media_type):
+					result = utils.getShowDetailsFromXBMC(data['dbid'], ['imdbnumber'])
+					if not result:
+						utils.Debug("No data was returned from XBMC, aborting manual %s." % args['action'])
+						return
+					data['imdbnumber'] = result['imdbnumber']
+
+				elif utils.isEpisode(media_type):
+					result = utils.getEpisodeDetailsFromXbmc(data['dbid'], ['showtitle', 'season', 'episode', 'tvshowid'])
+					if not result:
+						utils.Debug("No data was returned from XBMC, aborting manual %s." % args['action'])
+						return
+					data['tvdb_id'] = result['tvdb_id']
+					data['season'] = result['season']
+					data['episode'] = result['episode']
+
 			else:
 				if 'season' in data:
 					utils.Debug("Manual %s of non-library '%s' S%02dE%02d, with an ID of '%s'." % (args['action'], media_type, data['season'], data['episode'], data['remoteid']))
+					data['tvdb_id'] = data['remoteid']
 				else:
 					utils.Debug("Manual %s of non-library '%s' with an ID of '%s'." % (args['action'], media_type, data['remoteid']))
+					data['imdbnumber'] = data['remoteid']
+
 			if args['action'] == 'rate' and 'rating' in args:
 				if args['rating'] in ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']:
 					data['rating'] = int(args['rating'])
-			utils.setProperty('traktManualRateData', json.dumps(data))
-			utils.setProperty('traktManualRate', 'True')
+
+			data = {'action': 'manualRating', 'ratingData': data}
+
 		else:
 			utils.Debug("Manual %s of '%s' is unsupported." % (args['action'], media_type))
+
+	elif args['action'] == 'togglewatched':
+		media_type = getMediaType()
+		if media_type in ['movie', 'show', 'season', 'episode']:
+			data = {}
+			data['media_type'] = media_type
+			if utils.isMovie(media_type):
+				dbid = int(xbmc.getInfoLabel('ListItem.DBID'))
+				result = utils.getMovieDetailsFromXbmc(dbid, ['imdbnumber', 'title', 'year', 'playcount'])
+				if result:
+					if result['playcount'] == 0:
+						data['id'] = result['imdbnumber']
+					else:
+						utils.Debug("Movie alread marked as watched in XBMC.")
+				else:
+					utils.Debug("Error getting movie details from XBMC.")
+					return
+
+			elif utils.isEpisode(media_type):
+				dbid = int(xbmc.getInfoLabel('ListItem.DBID'))
+				result = utils.getEpisodeDetailsFromXbmc(dbid, ['showtitle', 'season', 'episode', 'tvshowid', 'playcount'])
+				if result:
+					if result['playcount'] == 0:
+						data['id'] = result['tvdb_id']
+						data['season'] = result['season']
+						data['episode'] = result['episode']
+					else:
+						utils.Debug("Episode already marked as watched in XBMC.")
+				else:
+					utils.Debug("Error getting episode details from XBMC.")
+					return
+
+			elif utils.isSeason(media_type):
+				showID = None
+				showTitle = xbmc.getInfoLabel('ListItem.TVShowTitle')
+				result = utils.xbmcJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetTVShows', 'params': {'properties': ['title', 'imdbnumber', 'year']}, 'id': 0})
+				if result and 'tvshows' in result:
+					for show in result['tvshows']:
+						if show['title'] == showTitle:
+							showID = show['tvshowid']
+							data['id'] = show['imdbnumber']
+							break
+				else:
+					utils.Debug("Error getting TV shows from XBMC.")
+					return
+
+				season = xbmc.getInfoLabel('ListItem.Season')
+				if season == "":
+					season = 0
+				else:
+					season = int(season)
+
+				result = utils.xbmcJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodes', 'params': {'tvshowid': showID, 'season': season, 'properties': ['season', 'episode', 'playcount']}, 'id': 0})
+				if result and 'episodes' in result:
+					episodes = []
+					for episode in result['episodes']:
+						if episode['playcount'] == 0:
+							episodes.append(episode['episode'])
+					
+					if len(episodes) == 0:
+						utils.Debug("'%s - Season %d' is already marked as watched." % (showTitle, season))
+						return
+
+					data['season'] = season
+					data['episodes'] = episodes
+				else:
+					utils.Debug("Error getting episodes from '%s' for Season %d" % (showTitle, season))
+					return
+
+			elif utils.isShow(media_type):
+				dbid = int(xbmc.getInfoLabel('ListItem.DBID'))
+				result = utils.getShowDetailsFromXBMC(dbid, ['year', 'imdbnumber'])
+				if not result:
+					utils.Debug("Error getting show details from XBMC.")
+					return
+				showTitle = result['label']
+				data['id'] = result['imdbnumber']
+				result = utils.xbmcJsonRequest({'jsonrpc': '2.0', 'method': 'VideoLibrary.GetEpisodes', 'params': {'tvshowid': dbid, 'properties': ['season', 'episode', 'playcount']}, 'id': 0})
+				if result and 'episodes' in result:
+					i = 0
+					s = {}
+					for e in result['episodes']:
+						season = str(e['season'])
+						if not season in s:
+							s[season] = []
+						if e['playcount'] == 0:
+							s[season].append(e['episode'])
+							i = i + 1
+
+					if i == 0:
+						utils.Debug("'%s' is already marked as watched." % showTitle)
+						return
+
+					data['seasons'] = dict((k, v) for k, v in s.iteritems() if v)
+				else:
+					utils.Debug("Error getting episode details for '%s' from XBMC." % showTitle)
+					return
+
+			if len(data) > 1:
+				utils.Debug("Marking '%s' with the following data '%s' as watched on trakt.tv" % (media_type, str(data)))
+				data['action'] = 'markWatched'
+
+		# execute toggle watched action
+		xbmc.executebuiltin("Action(ToggleWatched)")
+
+	q = queue.SqliteQueue()
+	if 'action' in data:
+		utils.Debug("Queuing for dispatch: %s" % data)
+		q.append(data)
 
 if __name__ == '__main__':
 	Main()

--- a/traktapi.py
+++ b/traktapi.py
@@ -460,8 +460,10 @@ class traktAPI(object):
 			Debug("[traktAPI] getSummary(url: %s)" % url)
 			return self.traktRequest('POST', url)
 
-	def getShowSummary(self, id):
+	def getShowSummary(self, id, extended=False):
 		data = str(id)
+		if extended:
+			data = "%s/extended" % data
 		return self.getSummary('show', data)
 	def getEpisodeSummary(self, id, season, episode):
 		data = "%s/%s/%s" % (id, season, episode)
@@ -470,6 +472,14 @@ class traktAPI(object):
 		data = str(id)
 		return self.getSummary('movie', data)
 
+	# url: http://api.trakt.tv/show/season.format/apikey/title/season
+	# returns: returns detailed episode info for a specific season of a show.
+	def getSeasonInfo(self, id, season):
+		if self.testAccount():
+			url = "%s/show/season.json/%s/%s/%d" % (self.__baseURL, self.__apikey, id, season)
+			Debug("[traktAPI] getSeasonInfo(url: %s)" % url)
+			return self.traktRequest('POST', url)
+	
 	# url: http://api.trakt.tv/rate/<show|episode|movie>/apikey
 	# returns: {"status":"success","message":"rated Portlandia 1x01","type":"episode","rating":"love","ratings":{"percentage":100,"votes":2,"loved":2,"hated":0},"facebook":true,"twitter":true,"tumblr":false}
 	def rate(self, type, data):

--- a/utilities.py
+++ b/utilities.py
@@ -143,6 +143,11 @@ def getFormattedItemName(type, info, short=False):
 			s = "S%02dE%02d - %s" % (info['episode']['season'], info['episode']['number'], info['episode']['title'])
 		else:
 			s = "%s - S%02dE%02d - %s" % (info['show']['title'], info['episode']['season'], info['episode']['number'], info['episode']['title'])
+	elif isSeason(type):
+		if info['season'] > 0:
+			s = "%s - Season %d" % (info['title'], info['season'])
+		else:
+			s = "%s - Specials" % info['title']
 	elif isMovie(type):
 		s = "%s (%s)" % (info['title'], info['year'])
 	return s


### PR DESCRIPTION
## Overview:

Since XBMC's python interface does not offer an event that triggers when an item's playcount changes, I decided to add a wrapper around XBMC's built in action ToggleWatched.
## Supported Methods:

There is only one way to use this:

```
RunScript(script.trakt,action=togglewatched)
```
## Information:

This new action, will ever only work on library items, consider it an extension of the sync features of the trakt script.

Best usage for this, would be to add the following to your keyboard.xml

```
<keymap>
  <MyVideoLibrary>
    <keyboard>
      <w>RunScript(script.trakt,action=togglewatched)</w>
    </keyboard>
  </MyVideoLibrary>
</keymap>
```

This will override XBMC's default action for W causing a ToggleWatched in the video library.

This works on all levels of the video library, movie, show, seasons, and episodes.

When an item or items are successfully marked as watched, a notification will popup indicating this, this can be toggled on/off via a setting.

Since this is an extension of the sync features, it also uses the simulate setting, so if this is enabled, it will do everything but actually update trakt.tv.  It will still do XBMC's built in ToggleWatched tho.

**Note:** this addition only works on library items, it won't be updated to support non-library items due to the amount of data that could potentially need to be passed along, and also, since it essentially wraps around XBMC's built in ToggleWatched action.

I've also added a fix for the BadStatusLine exception that started occuring a few days ago, I might split this out and open a PR of its own for it, have not decided yet.
## How it works
- For movies and episodes, it gets the item's playcount and other relevant data.
- For seasons, it will get the playcounts of all the items in the selected season, and add episodes to a list if there playcount is 0.
- For shows, you guessed it, it will get data for all the episodes, and add those episodes whose playcount is 0 to a list.
- If nothing is going has a playcount of 0, it skips dispatching to the service thread. Otherwise, it dispatches a new action to the scripts service thread with the data gathered above.
- It will now execute ToggleWatched on the item, so XBMC does its normal thing here.
- The service thread will take the data it got, and lookup information on trakt and filter out any items that are already watched, and finally, mark those that aren't as watched.
## Technical

This pull request introduces a new system for the dispatch queue.  Before it used python's built in Queue class to handle this.

Since branching out to actions in the script, it can not communicate easily with the service thread.  I was using window properties to trigger specific events, but, with manual rating, and this new addition, that could introduce race conditions.

So, I redid the dispatch system by using a sqlite database as the queue.  This eliminates any potential race conditions, lets script functions dispatch queue events that the service thread will pick up on, and is also thread safe.

I've gone through my movie list rapidly toggling movies as watched, and they all went through without a hiccup, the previous method, had issues with this.

Since I would consider this a core change, it needs to be thoroughly tested, on any platforms.  I run this on my HTPC, and everything works as expected, but, still needs testing.
## Other

As usual, enjoy, and feedback/etc is greatly welcome.
## Changes:
- Add a new action, togglewatched to wrap around the XBMC action, works only on library items, consider it an extension of the sync functions.
- Add settings to toggle notifications on/off for items marked as watched.
- ToggleWatched action uses the simulate_sync setting, so it can be easily tested.
- ToggleWatched will only mark as watched on trakt, it will not unwatch items, it checks XBMC data to build a list of what has a playcount of 0, and also checks data from trakt to see if the item is not watched already.
- Add new queue system for the dispatch queue, uses an sqlite database, this allows for script functions to send events to the service thread without the need to set properties which could cause race conditions.
- Update manual sync and manual rating to use new queue system.
- Update manual sync to get XBMC data in script call, instead of service, and pass this data, less to do in service thread now, makes it cleaner.
  Add new trakt api call, show/season to get season data for marking a season as watched
- Add extend option to getShowSummary
  Fix for BadStatusLine error.
