### PR TITLE
Alternate rating notification style

### DIFF
--- a/rating.py
+++ b/rating.py
@@ -73,17 +73,17 @@ def rateMedia(media_type, summary_info, unrate=False, rating=None):
 					utils.Debug("[Rating] Rating for '%s' is being set to '%d' manually." % (s, rating))
 					rateOnTrakt(rating, media_type, summary_info)
 				else:
-					utils.notification(s, utils.getString(1170) % utils.getFormattedType(media_type))
+					utils.notification(utils.getString(1174), s)
 					utils.Debug("[Rating] '%s' already has a rating of '%d'." % (s, rating))
 			else:
-				utils.notification(s, utils.getString(1168) % utils.getFormattedType(media_type))
+				utils.notification(utils.getString(1172), s)
 				utils.Debug("[Rating] '%s' is already rated." % s)
 		return
 
 	if summary_info['rating'] or summary_info['rating_advanced']:
 		if not rerate:
 			utils.Debug("[Rating] '%s' has already been rated." % s)
-			utils.notification(s, utils.getString(1168) % utils.getFormattedType(media_type))
+			utils.notification(utils.getString(1172), s)
 			return
 		else:
 			utils.Debug("[Rating] '%s' is being re-rated." % s)
@@ -156,12 +156,18 @@ def rateOnTrakt(rating, media_type, media, unrate=False):
 	else:
 		return
 
-	if data != None:
+	if data:
 		s = utils.getFormattedItemName(media_type, media)
-		if not unrate:
-			utils.notification(s, utils.getString(1167) % utils.getFormattedType(media_type))
+		if 'status' in data and data['status'] == "success":
+			if not unrate:
+				utils.notification(utils.getString(1171), s)
+			else:
+				utils.notification(utils.getString(1173), s)
+		elif 'status' in data and data['status'] == "failure":
+			utils.notification(utils.getString(1175), s)
 		else:
-			utils.notification(s, utils.getString(1169) % utils.getFormattedType(media_type))
+			# status not in data, different problem, do nothing for now
+			pass
 
 class RatingDialog(xbmcgui.WindowXMLDialog):
 	buttons = {

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -37,6 +37,11 @@
 	<string id="1168">%s has already been rated</string>
 	<string id="1169">%s successfully unrated</string>
 	<string id="1170">%s already has the same rating</string>
+	<string id="1171">trakt.tv - Rating submitted successfully</string>
+	<string id="1172">trakt.tv - Already rated</string>
+	<string id="1173">trakt.tv - Unrated successfully</string>
+	<string id="1174">trakt.tv - Already has the same rating</string>
+	<string id="1175">trakt.tv - Problem submitting rating</string>
 	<string id="1313">What Did You Think?</string>
 	<string id="1314">Totally Ninja!</string>
 	<string id="1315">Weak Sauce :(</string>


### PR DESCRIPTION
Alternate rating notification style, status is on the left, and the title of the item is on the right, which can scroll if its to long.

This is completely optional, and probably does look/work a bit better, but try it out and provide feedback

Its the styling that @ezechiel1917 suggested with the status on the left, since these will be shorter, and the item title on the right where it can scroll if its to long.

I've added the status lines as new string instead of replacing them for now, will go through and cleanup the strings before 2.3 is released if this is merged in.

Also, I've added a check for success/failure in the rating result from trakt, so it will now also show "trakt.tv - Problem submitting rating" if the status was failure.
