### PR TITLE
Add ability to edit list within managelists dialog

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -192,6 +192,17 @@
 	<string id="1664">There was a problem loading your watchlists</string>
 	<string id="1665">There was a problem loading your rating data</string>
 	<string id="1666">Tags/Lists have been updated</string>
+	<string id="1667">Privacy Setting</string>
+	<string id="1668">Other Settings</string>
+	<string id="1669">Edit Description</string>
+	<string id="1670">Rename List</string>
+	<string id="1671">Public</string>
+	<string id="1672">Friends</string>
+	<string id="1673">Private</string>
+	<string id="1674">Allow Shouts</string>
+	<string id="1675">Show Numbers</string>
+	<string id="1676">Hide in Item List</string>
+	<string id="1677">Can't rename to an already existing list %s</string>
 	
 	<!-- Debug Settings -->
 	<string id="1700">Debug</string>

--- a/resources/skins/Default/720p/traktListDialog.xml
+++ b/resources/skins/Default/720p/traktListDialog.xml
@@ -144,11 +144,210 @@
 				<textureslidernib>ScrollBarNib.png</textureslidernib>
 				<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
 				<onleft>4</onleft>
-				<onright>16</onright>
+				<onright>111</onright>
 				<ondown>61</ondown>
 				<onup>61</onup>
 				<showonepage>false</showonepage>
 				<orientation>vertical</orientation>
+			</control>
+			<control type="group" id="100">
+				<defaultcontrol>111</defaultcontrol>
+				<posx>20</posx>
+				<posy>245</posy>
+				<width>550</width>
+				<height>230</height>
+				<control type="label" id="110">
+					<description>Title</description>
+					<posx>10</posx>
+					<posy>0</posy>
+					<width>270</width>
+					<height>20</height>
+					<label>$ADDON[script.trakt 1667]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font12</font>
+					<textcolor>FFBBBBBB</textcolor>
+				</control>
+				<control type="list" id="111">
+					<posx>25</posx>
+					<posy>30</posy>
+					<width>240</width>
+					<height>138</height>
+					<onup>4</onup>
+					<ondown>113</ondown>
+					<onleft>61</onleft>
+					<onright>141</onright>
+					<scrolltime>200</scrolltime>
+					<itemlayout height="46" width="240">
+						<control type="image">
+							<posx>0</posx>
+							<posy>0</posy>
+							<width>240</width>
+							<height>40</height>
+							<texture border="5">button-nofocus.png</texture>
+						</control>
+						<control type="label">
+							<posx>120</posx>
+							<posy>0</posy>
+							<width>200</width>
+							<height>40</height>
+							<font>font13</font>
+							<textcolor>white</textcolor>
+							<selectedcolor>FFEB9E17</selectedcolor>
+							<align>center</align>
+							<aligny>center</aligny>
+							<info>ListItem.Label</info>
+						</control>
+					</itemlayout>
+					<focusedlayout height="46" width="240">
+						<control type="image">
+							<posx>0</posx>
+							<posy>0</posy>
+							<width>240</width>
+							<height>40</height>
+							<texture border="5">button-nofocus.png</texture>
+							<visible>!Control.HasFocus(111)</visible>
+							<animation effect="fade" time="300">Visible</animation>
+							<animation effect="fade" time="300">Hidden</animation>
+						</control>
+						<control type="image">
+							<posx>0</posx>
+							<posy>0</posy>
+							<width>240</width>
+							<height>40</height>
+							<texture border="5">button-focus2.png</texture>
+							<visible>Control.HasFocus(111)</visible>
+							<animation effect="fade" time="300">Visible</animation>
+							<animation effect="fade" time="300">Hidden</animation>
+						</control>
+						<control type="label">
+							<posx>120</posx>
+							<posy>0</posy>
+							<width>200</width>
+							<height>40</height>
+							<font>font13</font>
+							<textcolor>white</textcolor>
+							<selectedcolor>FFEB9E17</selectedcolor>
+							<align>center</align>
+							<aligny>center</aligny>
+							<info>ListItem.Label</info>
+						</control>
+					</focusedlayout>
+				</control>
+				<control type="label" id="140">
+					<description>Title</description>
+					<posx>290</posx>
+					<posy>0</posy>
+					<width>270</width>
+					<height>20</height>
+					<label>$ADDON[script.trakt 1668]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<font>font12</font>
+					<textcolor>FFBBBBBB</textcolor>
+				</control>
+				<control type="list" id="141">
+					<posx>305</posx>
+					<posy>30</posy>
+					<width>240</width>
+					<height>138</height>
+					<onup>4</onup>
+					<ondown>114</ondown>
+					<onleft>111</onleft>
+					<onright>113</onright>
+					<scrolltime>200</scrolltime>
+					<itemlayout height="46" width="240">
+						<control type="image">
+							<posx>0</posx>
+							<posy>0</posy>
+							<width>240</width>
+							<height>40</height>
+							<texture border="5">button-nofocus.png</texture>
+						</control>
+						<control type="label">
+							<posx>120</posx>
+							<posy>0</posy>
+							<width>200</width>
+							<height>40</height>
+							<font>font13</font>
+							<textcolor>white</textcolor>
+							<selectedcolor>FFEB9E17</selectedcolor>
+							<align>center</align>
+							<aligny>center</aligny>
+							<info>ListItem.Label</info>
+						</control>
+					</itemlayout>
+					<focusedlayout height="46" width="240">
+						<control type="image">
+							<posx>0</posx>
+							<posy>0</posy>
+							<width>240</width>
+							<height>40</height>
+							<texture border="5">button-nofocus.png</texture>
+							<visible>!Control.HasFocus(141)</visible>
+							<animation effect="fade" time="300">Visible</animation>
+							<animation effect="fade" time="300">Hidden</animation>
+						</control>
+						<control type="image">
+							<posx>0</posx>
+							<posy>0</posy>
+							<width>240</width>
+							<height>40</height>
+							<texture border="5">button-focus2.png</texture>
+							<visible>Control.HasFocus(141)</visible>
+							<animation effect="fade" time="300">Visible</animation>
+							<animation effect="fade" time="300">Hidden</animation>
+						</control>
+						<control type="label">
+							<posx>120</posx>
+							<posy>0</posy>
+							<width>200</width>
+							<height>40</height>
+							<font>font13</font>
+							<textcolor>white</textcolor>
+							<selectedcolor>FFEB9E17</selectedcolor>
+							<align>center</align>
+							<aligny>center</aligny>
+							<info>ListItem.Label</info>
+						</control>
+					</focusedlayout>
+				</control>
+				<control type="button" id="113">
+					<description>Manual button</description>
+					<posx>10</posx>
+					<posy>180</posy>
+					<width>270</width>
+					<height>40</height>
+					<label>$ADDON[script.trakt 1669]</label>
+					<font>font12_title</font>
+					<textcolor>white</textcolor>
+					<focusedcolor>white</focusedcolor>
+					<align>center</align>
+					<onleft>141</onleft>
+					<onright>114</onright>
+					<texturenofocus border="5">button-nofocus.png</texturenofocus>
+					<texturefocus border="5">button-focus2.png</texturefocus>
+					<onup>111</onup>
+					<ondown>16</ondown>
+				</control>
+				<control type="button" id="114">
+					<description>Manual button</description>
+					<posx>290</posx>
+					<posy>180</posy>
+					<width>270</width>
+					<height>40</height>
+					<label>$ADDON[script.trakt 1670]</label>
+					<font>font12_title</font>
+					<textcolor>white</textcolor>
+					<focusedcolor>white</focusedcolor>
+					<align>center</align>
+					<onleft>113</onleft>
+					<onright>16</onright>
+					<texturenofocus border="5">button-nofocus.png</texturenofocus>
+					<texturefocus border="5">button-focus2.png</texturefocus>
+					<onup>141</onup>
+					<ondown>16</ondown>
+				</control>
 			</control>
 			<control type="button" id="15">
 				<description>Manual button</description>
@@ -161,12 +360,12 @@
 				<textcolor>white</textcolor>
 				<focusedcolor>white</focusedcolor>
 				<align>center</align>
-				<onleft>61</onleft>
+				<onleft>114</onleft>
 				<onright>16</onright>
 				<texturenofocus border="5">button-nofocus.png</texturenofocus>
 				<texturefocus border="5">button-focus2.png</texturefocus>
-				<onup>4</onup>
-				<ondown>4</ondown>
+				<onup>100</onup>
+				<ondown>100</ondown>
 			</control>
 			<control type="button" id="16">
 				<description>Manual button</description>
@@ -183,8 +382,8 @@
 				<onright>17</onright>
 				<texturenofocus border="5">button-nofocus.png</texturenofocus>
 				<texturefocus border="5">button-focus2.png</texturefocus>
-				<onup>4</onup>
-				<ondown>4</ondown>
+				<onup>100</onup>
+				<ondown>100</ondown>
 			</control>
 			<control type="button" id="17">
 				<description>Manual button</description>
@@ -201,8 +400,8 @@
 				<onright>4</onright>
 				<texturenofocus border="5">button-nofocus.png</texturenofocus>
 				<texturefocus border="5">button-focus2.png</texturefocus>
-				<onup>4</onup>
-				<ondown>4</ondown>
+				<onup>100</onup>
+				<ondown>100</ondown>
 			</control>
 		</control>
 	</controls>

--- a/traktapi.py
+++ b/traktapi.py
@@ -520,8 +520,10 @@ class traktAPI(object):
 			Debug("[traktAPI] userList(url: %s, data: %s)" % (url, str(data)))
 			return self.traktRequest('POST', url, data, passVersions=True)
 	
-	def userListAdd(self, list_name, privacy, show_numbers=False, allow_shouts=False):
+	def userListAdd(self, list_name, privacy, description=None, allow_shouts=False, show_numbers=False):
 		data = {'name': list_name, 'show_numbers': show_numbers, 'allow_shouts': allow_shouts, 'privacy': privacy}
+		if description:
+			data['description'] = description
 		return self.userList('add', data)
 	def userListDelete(self, slug_name):
 		data = {'slug': slug_name}
@@ -530,6 +532,8 @@ class traktAPI(object):
 		return self.userList('items/add', data)
 	def userListItemDelete(self, data):
 		return self.userList('items/delete', data)
+	def userListUpdate(self, data):
+		return self.userList('update', data)
 
 	# url: http://api.trakt.tv/user/watchlist/<movies|shows>.json/<apikey>/<username>
 	# returns: [{"title":"GasLand","year":2010,"released":1264320000,"url":"http://trakt.tv/movie/gasland-2010","runtime":107,"tagline":"Can you light your water on fire? ","overview":"It is happening all across America-rural landowners wake up one day to find a lucrative offer from an energy company wanting to lease their property. Reason? The company hopes to tap into a reservoir dubbed the \"Saudi Arabia of natural gas.\" Halliburton developed a way to get the gas out of the ground-a hydraulic drilling process called \"fracking\"-and suddenly America finds itself on the precipice of becoming an energy superpower.","certification":"","imdb_id":"tt1558250","tmdb_id":"40663","inserted":1301130302,"images":{"poster":"http://trakt.us/images/posters_movies/1683.jpg","fanart":"http://trakt.us/images/fanart_movies/1683.jpg"},"genres":["Action","Comedy"]},{"title":"The King's Speech","year":2010,"released":1291968000,"url":"http://trakt.tv/movie/the-kings-speech-2010","runtime":118,"tagline":"God save the king.","overview":"Tells the story of the man who became King George VI, the father of Queen Elizabeth II. After his brother abdicates, George ('Bertie') reluctantly assumes the throne. Plagued by a dreaded stutter and considered unfit to be king, Bertie engages the help of an unorthodox speech therapist named Lionel Logue. Through a set of unexpected techniques, and as a result of an unlikely friendship, Bertie is able to find his voice and boldly lead the country into war.","certification":"R","imdb_id":"tt1504320","tmdb_id":"45269","inserted":1301130174,"images":{"poster":"http://trakt.us/images/posters_movies/8096.jpg","fanart":"http://trakt.us/images/fanart_movies/8096.jpg"},"genres":["Action","Comedy"]}]

--- a/utilities.py
+++ b/utilities.py
@@ -44,8 +44,21 @@ def getSettingAsInt(setting):
     except ValueError:		
         return 0
 
+def getSettingAsList(setting):
+	data = getSetting(setting)
+	try:
+		return json.loads(data)
+	except ValueError:
+		return []
+
 def setSetting(setting, value):
 	__addon__.setSetting(setting, str(value))
+
+def setSettingFromList(setting, value):
+	if value is None:
+		value = []
+	data = json.dumps(value)
+	setSetting(setting, data)
 
 def getString(string_id):
     return __addon__.getLocalizedString(string_id).encode('utf-8', 'ignore')


### PR DESCRIPTION
Some additions to the tagging ability.
- Edit managelists dialog to include controls for editing a list, these will be visible once a list is selected.
- Added ability to hide a list in the itemslist dialog, useful for if you have some lists that you just don't want to use in XBMC.
- managelists dialog remembers your list selection when returning to the from editing a list.
