### PR TITLE
Some fixes and cleanup

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -20,6 +20,8 @@
 	<string id="1041">Scrobble movies</string>
 	<string id="1042">Scrobble TV episodes</string>
 	<string id="1043">Minimum percent watched to scrobble</string>
+	<string id="1044">During scrobbling, update ID for library movie if ID is missing</string>
+	<string id="1045">During scrobbling, update ID for library tv show if ID is missing</string>
 	<string id="1050">Exclusions</string>
 	<string id="1051">Exclude Live TV</string>
 	<string id="1052">Exclude HTTP sources</string>	

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,6 +10,8 @@
 		<setting id="scrobble_movie" type="bool" label="1041" default="true"/>
 		<setting id="scrobble_episode" type="bool" label="1042" default="true"/>
 		<setting id="scrobble_min_view_time" type="slider" label="1043" range="0,5,100" default="80"/>
+		<setting id="update_imdb_id" type="bool" label="1044" default="false"/>
+		<setting id="update_tvdb_id" type="bool" label="1045" default="false"/>
 		<setting type="sep"/>
 		<setting label="1050" type="lsep"/><!--Exclusions -->
 		<setting id="ExcludeLiveTV" type="bool" label="1051" default="false"/>

--- a/service.py
+++ b/service.py
@@ -406,7 +406,13 @@ class traktPlayer(xbmc.Player):
 			utilities.Debug("[traktPlayer] onPlayBackStarted() - %s" % result)
 
 			# check for exclusion
-			_filename = self.getPlayingFile()
+			_filename = None
+			try:
+				_filename = self.getPlayingFile()
+			except:
+				utilities.Debug("[traktPlayer] onPlayBackStarted() - Exception trying to get playing filename, player stopped suddently.")
+				return
+
 			if utilities.checkScrobblingExclusion(_filename):
 				utilities.Debug("[traktPlayer] onPlayBackStarted() - '%s' is in exclusion settings, ignoring." % _filename)
 				return

--- a/tagging.py
+++ b/tagging.py
@@ -492,6 +492,11 @@ class Tagger():
 				xbmc_update['movies'].extend(trakt_lists[listName]['movies'])
 				xbmc_update['shows'].extend(trakt_lists[listName]['shows'])
 
+		for list_name in xbmc_lists:
+			if not list_name in trakt_lists:
+				xbmc_update['movies'].extend(xbmc_lists[listName]['movies'])
+				xbmc_update['shows'].extend(xbmc_lists[listName]['shows'])
+				
 		tTaken = time() - tStart
 		utils.Debug("[Tagger] Time to compare data: %0.3f seconds." % tTaken)
 
@@ -593,24 +598,18 @@ class Tagger():
 
 				# apply changes and create new lists first.
 				tStart = time()
-				for list_name in self.traktLists:
-					if list_name in _listData:
-						slug = self.traktLists[list_name]
-						_listData[slug] = _listData.pop(list_name)
-						_listData[slug]['slug'] = slug
-
-				_changed = []
-				_added = []
+				_lists_changed = []
+				_lists_added = []
 				keys_ignore = ['hide', 'slug', 'url']
 				for slug in _listData:
 					if not slug in self.traktListData:
-						_added.append(slug)
+						_lists_added.append(slug)
 						continue
 					for key in _listData[slug]:
 						if key in keys_ignore:
 							continue
 						if not _listData[slug][key] == self.traktListData[slug][key]:
-							_changed.append(slug)
+							_lists_changed.append(slug)
 							break
 
 				_old_hidden = [slug for slug in self.traktListData if self.traktListData[slug]['hide']]
@@ -619,8 +618,8 @@ class Tagger():
 					utils.Debug("[Tagger] Updating hidden lists to '%s'." % str(_new_hidden))
 					utils.setSettingFromList('tagging_hidden_lists', _new_hidden)
 
-				if _changed:
-					for slug in _changed:
+				if _lists_changed:
+					for slug in _lists_changed:
 						params = {}
 						params['slug'] = slug
 						for key in _listData[slug]:
@@ -643,8 +642,8 @@ class Tagger():
 									_listData[new_slug] = _listData.pop(slug)
 									_listData[new_slug]['slug'] = new_slug
 
-				if _added:
-					for list_name in _added:
+				if _lists_added:
+					for list_name in _lists_added:
 						list_data = _listData[list_name]
 						result = self.traktapi.userListAdd(list_name, list_data['privacy'], list_data['description'], list_data['allow_shouts'], list_data['show_numbers'])
 


### PR DESCRIPTION
Some fixes & cleanup, needs to be tested before merge.

Fixes a runtime error that could occur on a playback start.

If rate after watch is enabled, it would get summary info irregardless of if it couldn't actually get anything (due to missing imdb_id or tvdb_id in library). It now checks for this and outputs to log.  And will try to get summary info after a successful watch (like how non-library items are done), and there is also an option to update your library's info with this ID.

Removed a check from the main update function in the scrobbler, use to check if the video was paused (internal flag toggled), I've removed this to prevent issues where this paused variable could become incorrect and cause the time updates to never happen.
## Changelog:
- Fix for RuntimeError
- Cleanup in tagging.py
- Update function that updates the current media's playing time, remove check for paused, this will prevent updates not happening if resume/pause gets messed up.
  If library item is missing imdb or tvdb id, and rating is enabled, don't get summary, get it after a watching call instead.  This will stop API calls being made that can never return data.
- Added ability to update library item's imdb/tvdb id from watching calls if they are missing.
- Added 2 new settings to control the ability to update a library item's imdb and tvdb id.
- Fix for watchlist tag check
