### PR TITLE
Fix for UnicodeEncodeError in notification function.

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -24,7 +24,7 @@ def Debug(msg, force = False):
 			print "[trakt] " + msg.encode('utf-8', 'ignore')
 
 def notification(header, message, time=5000, icon=__addon__.getAddonInfo('icon')):
-	xbmc.executebuiltin("XBMC.Notification(%s,%s,%i,%s)" % (header, message, time, icon))
+	xbmc.executebuiltin("XBMC.Notification(%s,%s,%i,%s)" % (header, message.encode('utf-8', 'ignore'), time, icon))
 
 def getSetting(setting):
     return __addon__.getSetting(setting).strip()


### PR DESCRIPTION
Add encode method to message string in utilities notification function.

Encountered this error when I manually marked an episode 'Jo - S01E05 - Place Vendôme' as watched in XBMC, the **ô** triggered the error.  This is fixed in the notification helper function, by encoding the message to utf-8 in the string formatting.

Since this is a helper used throughout the plugin, may solve other encode errors not yet encountered.

Needs to be tested to make sure it doesn't have any side effects, but I don't believe there are any.
