### PR TITLE
Some fixes and tweaks

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -6,6 +6,7 @@
 	<string id="1014">Password</string>
 	<string id="1017">Number of Retries</string>
 	<string id="1018">Startup Delay</string>
+	<string id="1019">Force a reload of settings from trakt.tv, save settings when finished</string>
 	
 	<!-- Rating Settings -->
 	<string id="1030">Rating</string>
@@ -34,6 +35,7 @@
 	<string id="1108">Can't connect to trakt</string>
 	<string id="1109">Error</string>
 	<string id="1110">Incorrect username or password</string>
+	<string id="1111">Loading settings from trakt.tv</string>
 
 	<!-- Manual Rating Notifications -->
 	<string id="1350">trakt.tv - Rating submitted successfully</string>
@@ -209,8 +211,9 @@
 	<!-- Debug Settings -->
 	<string id="1700">Debug</string>
 	<string id="1701">Enable debug mode</string>
-	<string id="1702">Simulate scrobbling (for testing purposes)</string>
-	<string id="1703">Simulate sync (for testing purposes)</string>
+	<string id="1702">Simulate scrobbling</string>
+	<string id="1703">Simulate sync</string>
 	<string id="1704">Simulate tagging</string>
-	<string id="1705">Run timing tests, see log for output</string>
+	<string id="1720">Logging</string>
+	<string id="1721">Simulate settings, if enabled will not make changes in XBMC or trakt.tv</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,6 +5,7 @@
 		<setting id="password" type="text" option="hidden" label="1014" default="" />
 		<setting id="retries" type="slider" label="1017" range="1,1,10" default="5" option="int"/>
 		<setting id="startup_delay" type="slider" label="1018" range="0,30" default="0" option="int"/>
+		<setting type="action" label="1019" action="RunScript(script.trakt,action=loadsettings)"/>
 	</category>
 	<category label="1040"><!-- Scrobbling -->
 		<setting id="scrobble_movie" type="bool" label="1041" default="true"/>
@@ -59,10 +60,12 @@
 		<setting id="tagging_notifications" type="bool" label="1608" default="true"/>
 	</category>
 	<category label="1700"><!-- Debug -->
+		<setting label="1720" type="lsep"/>
 		<setting id="debug" type="bool" label="1701" default="true"/>
+		<setting type="sep"/>
+		<setting label="1721" type="lsep"/>
 		<setting id="simulate_scrobbling" type="bool" label="1702" default="false"/>
 		<setting id="simulate_sync" type="bool" label="1703" default="false"/>
 		<setting id="simulate_tagging" type="bool" label="1704" default="false"/>
-		<setting type="action" label="1705" action="RunScript(script.trakt,action=timertest)"/>
 	</category>
 </settings>

--- a/script.py
+++ b/script.py
@@ -48,6 +48,10 @@ def Main():
 	if args['action'] == 'sync':
 		data = {'action': 'manualSync'}
 
+	elif args['action'] == 'loadsettings':
+		data = {'action': 'loadsettings', 'force': True}
+		utils.notification(utils.getString(1201), utils.getString(1111))
+
 	elif args['action'] in ['rate', 'unrate']:
 		data = {}
 		data['action'] = args['action']

--- a/service.py
+++ b/service.py
@@ -96,6 +96,11 @@ class traktService:
 			list = data['list']
 			del data['list']
 			self.tagger.manualRemoveFromList(list, data)
+		elif action == 'loadsettings':
+			force = False
+			if 'force' in data:
+				force = data['force']
+			globals.traktapi.getAccountSettings(force)
 		else:
 			utilities.Debug("Unknown dispatch action, '%s'." % action)
 
@@ -106,6 +111,12 @@ class traktService:
 			xbmc.sleep(startup_delay * 1000)
 
 		utilities.Debug("Service thread starting.")
+
+		# purge queue before doing anything
+		self.dispatchQueue.purge()
+
+		# queue a loadsettings action
+		self.dispatchQueue.append({'action': 'loadsettings'})
 
 		# setup event driven classes
 		self.Player = traktPlayer(action = self._dispatchQueue)
@@ -123,9 +134,6 @@ class traktService:
 		# init tagging class
 		self.tagger = Tagger(globals.traktapi)
 		
-		# purge queue
-		self.dispatchQueue.purge()
-
 		# start loop for events
 		while (not xbmc.abortRequested):
 			while len(self.dispatchQueue) and (not xbmc.abortRequested):


### PR DESCRIPTION
Some general fixes and a few tweaks.

Purge the dispatch queue before doing anything, instead of after creating all the classes.

Changed how settings are loaded, they're no longer loaded by default when creating the traktAPI class, which could possibly take a while.  They are now a dispatch action, which is the first thing that gets done when the plugin enters its loop.

The addon now caches the settings from trakt.tv, and will refresh them one week (less an hour) from the last time they were cached.  And you can also force the settings to load from within the configure screen (need to OK out of the settings for them to save tho).

Made a few changes in the settings dialog as well.  Added separators in the debug section, and removed the timer test execute entry, can still be run manually other ways, but will be removing this completely, eventually.
## Changes
- On initial load, purge old queue before doing anything.
- No longer load settings on trakt api creation, variable is there to force it if needed.
- Move load settings to a dispatch action.
- Add load settings to dispatch after purging queue, so its the first thing that gets done when loop is entered.
- Cache settings when they're loaded and refresh them a week (less an hour) from the last time they were cached.
- Add ability to force settings to be reloaded in addon configure screen.
- Rework settings a bit, add separators in debug section.
