### PR TITLE
Some fixes and changes

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -24,6 +24,8 @@
 	<string id="1043">Minimum percent watched to scrobble</string>
 	<string id="1044">During scrobbling, update ID for library movie if ID is missing</string>
 	<string id="1045">During scrobbling, update ID for library tv show if ID is missing</string>
+	<string id="1046">Send watching call on seek</string>
+	<string id="1047">Send watching call on resume</string>
 	<string id="1050">Exclusions</string>
 	<string id="1051">Exclude Live TV</string>
 	<string id="1052">Exclude HTTP sources</string>	

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -24,6 +24,8 @@
 		<setting id="scrobble_min_view_time" type="slider" label="1043" range="0,5,100" default="80"/>
 		<setting id="update_imdb_id" type="bool" label="1044" default="false"/>
 		<setting id="update_tvdb_id" type="bool" label="1045" default="false"/>
+		<setting id="watching_call_on_seek" type="bool" label="1046" default="true"/>
+		<setting id="watching_call_on_resume" type="bool" label="1047" default="true"/>
 	</category>
 	<category label="1400"><!-- Synchronize -->
 		<setting label="1410" type="lsep"/><!-- Service -->

--- a/scrobbler.py
+++ b/scrobbler.py
@@ -175,7 +175,8 @@ class Scrobbler():
 			self.pausedAt = 0
 			self.isPaused = False
 			self.update(True)
-			self.watching()
+			if utilities.getSettingAsBool('watching_call_on_resume'):
+				self.watching()
 
 	def playbackPaused(self):
 		if not self.isPlaying:
@@ -193,7 +194,8 @@ class Scrobbler():
 
 		Debug("[Scrobbler] playbackSeek()")
 		self.update(True)
-		self.watching()
+		if utilities.getSettingAsBool('watching_call_on_seek'):
+			self.watching()
 
 	def playbackEnded(self):
 		if not self.isPlaying:
@@ -241,7 +243,7 @@ class Scrobbler():
 							self.curVideoInfo['imdbnumber'] = response['movie']['imdb_id']
 							if 'id' in self.curVideo and utilities.getSettingAsBool('update_imdb_id'):
 								req = {"jsonrpc": "2.0", "id": 1, "method": "VideoLibrary.SetMovieDetails", "params": {"movieid" : self.curVideoInfo['movieid'], "imdbnumber": self.curVideoInfo['imdbnumber']}}
-								utils.xbmcJsonRequest(req)
+								utilities.xbmcJsonRequest(req)
 							# get summary data now if we are rating this movie
 							if utilities.getSettingAsBool('rate_movie') and self.traktSummaryInfo is None:
 								Debug("[Scrobbler] Movie rating is enabled, pre-fetching summary information.")
@@ -265,7 +267,7 @@ class Scrobbler():
 							self.curVideoInfo['tvdb_id'] = response['show']['tvdb_id']
 							if 'id' in self.curVideo and utilities.getSettingAsBool('update_tvdb_id'):
 								req = {"jsonrpc": "2.0", "id": 1, "method": "VideoLibrary.SetTVShowDetails", "params": {"tvshowid" : self.curVideoInfo['tvshowid'], "imdbnumber": self.curVideoInfo['tvdb_id']}}
-								utils.xbmcJsonRequest(req)
+								utilities.xbmcJsonRequest(req)
 							# get summary data now if we are rating this episode
 							if utilities.getSettingAsBool('rate_episode') and self.traktSummaryInfo is None:
 								Debug("[Scrobbler] Episode rating is enabled, pre-fetching summary information.")
@@ -351,7 +353,7 @@ class Scrobbler():
 				tagging.xbmcSetTags(id, self.curVideo['type'], s, tags)
 
 		else:
-			utils.Debug("No data was returned from XBMC, aborting tag udpate.")
+			utilities.Debug("No data was returned from XBMC, aborting tag udpate.")
 
 	def check(self):
 		scrobbleMinViewTimeOption = utilities.getSettingAsFloat("scrobble_min_view_time")

--- a/sync.py
+++ b/sync.py
@@ -426,11 +426,15 @@ class Sync():
 		xbmcShows = self.xbmcLoadShows()
 		if not isinstance(xbmcShows, list) and not xbmcShows:
 			Debug("[Episodes Sync] XBMC show list is empty, aborting tv show Sync.")
+			if self.show_progress and not self.run_silent:
+				progress.close()
 			return
 
 		traktShows = self.traktLoadShows()
 		if not isinstance(traktShows, list):
 			Debug("[Episodes Sync] Error getting trakt.tv show list, aborting tv show sync.")
+			if self.show_progress and not self.run_silent:
+				progress.close()
 			return
 
 		if utilities.getSettingAsBool('add_episodes_to_trakt') and not self.isCanceled():
@@ -709,11 +713,15 @@ class Sync():
 		xbmcMovies = self.xbmcLoadMovies()
 		if not isinstance(xbmcMovies, list) and not xbmcMovies:
 			Debug("[Movies Sync] XBMC movie list is empty, aborting movie Sync.")
+			if self.show_progress and not self.run_silent:
+				progress.close()
 			return
 
 		traktMovies = self.traktLoadMovies()
 		if not isinstance(traktMovies, list):
 			Debug("[Movies Sync] Error getting trakt.tv movie list, aborting movie Sync.")
+			if self.show_progress and not self.run_silent:
+				progress.close()
 			return
 
 		if utilities.getSettingAsBool('add_movies_to_trakt') and not self.isCanceled():


### PR DESCRIPTION
I've added the ability to disable sending watching API calls during seek events and when resuming a video.  It will still send watching calls every 10 minutes irregardless as usual.  The main purpose of this is for those who have slower connections to cut down on the number of times trakt.tv is hit.  Main example for this is if seeking through a movie, in 10 minute steps, to the end to scrobble it, and the user is on a slower connection where it consistantly takes 20+ seconds to get results from trakt.tv.

I've also fixed the progress dialog staying on screen during a manual sync (if enabled) when data from trakt or xbmc is invalid and it cancels itself.  Seems I forgot to close the progress dialog in these instances.

I've also fixed possible crashes in scrobbler, was using the wrong class for some calls, not sure how I missed them.

As usual, needs testing, and feedback welcome.
## Changelog
- Fix possible crashes in scrobbler.py
- Add ability to disable sending watched calls on seek and when resuming playback, this can cut down on wait times from the API, for example playing a movie and seeking to the end in 10 minute skips to scrobble it.  This would mainly benefit those who usually have long response times from trakt.tv
- Close progress dialog if results from trakt or xbmc are invalid, otherwise dialog stays on screen with no way to remove it
