### PR TITLE
Workaround fix for UnicodeDecodeError

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -96,7 +96,11 @@ def isValidMediaType(type):
 def xbmcJsonRequest(params):
 	data = json.dumps(params)
 	request = xbmc.executeJSONRPC(data)
-	response = json.loads(request)
+	try:
+		response = json.loads(request)
+	except UnicodeDecodeError, e:
+		Debug("xbmcJsonRequest: UnicodeDecodeError: '%s', Data: '%s'" % (e.message, response))
+		response = json.loads(request.decode('utf-8', 'ignore'))
 
 	try:
 		if 'result' in response:


### PR DESCRIPTION
I don't know if this would be considered a work around, a fix, or what, but, it does fix the issue.  I'm waiting for some more logs to confirm this, but from my tests it seems to.

On the XBMC forums, bladel and soder were having UnicodeDecodeErrors coming from xbmcJsonRequests during sync and during playback started.

As for this change, I know this could be done easily in 1 line, just doing the ignore, I opted for wrapping it in a try/except to give an indication in the log of when its happening.

Another common thing between the occurrence of this error, is the base version of XBMC used, in this case it was Openelec.  Now I don't know if there is anything to this, but the fact that it was mentioned that it was tested in windows XBMC and it worked makes me wonder.

I tried this change on my main HTPC (windows based) tonight and everything worked as it should, so unfortunately this is one of those things that needs to be tested and seems to be a relatively rare case since it hasn't come up before, at least not that has been mentioned.
## Changes

Workaround fix for UnicodeDecodeError which seems to occur when json tries to parse a response string from executeJSONRPC.
