### PR TITLE
Add setting to show or hide automatic sync notifications during playback...

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -82,6 +82,7 @@
 	<string id="1413">Clean trakt movie collection</string>
 	<string id="1414">Clean trakt episode collection</string>
 	<string id="1416">Show marked as watched notification</string>
+	<string id="1417">Hide notifications during playback</string>
 
 	<!-- Sync Notifications -->
 	<string id="1420">Sync started</string>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -31,6 +31,7 @@
 		<setting label="1410" type="lsep"/><!-- Service -->
 		<setting id="sync_on_update" type="bool" label="1411" default="false"/>
 		<setting id="show_sync_notifications" type="bool" label="1412" default="false"/>
+		<setting id="hide_notifications_playback" type="bool" label="1417" default="false"/>
 		<setting id="show_marked_notification" type="bool" label="1416" default="true"/>
 		<setting type="sep"/>
 		<setting label="1402" type="lsep"/><!-- Movies -->

--- a/sync.py
+++ b/sync.py
@@ -18,6 +18,7 @@ class Sync():
 			Debug("[Sync] Sync is being run silently.")
 		self.sync_on_update = utilities.getSettingAsBool('sync_on_update')
 		self.notify = utilities.getSettingAsBool('show_sync_notifications')
+		self.notify_during_playback = not (xbmc.Player().isPlayingVideo() and utilities.getSettingAsBool("hide_notifications_playback"))
 		self.simulate = utilities.getSettingAsBool('simulate_sync')
 		if self.simulate:
 			Debug("[Sync] Sync is configured to be simulated.")
@@ -419,7 +420,7 @@ class Sync():
 		self.updateProgress(82, line2=utilities.getString(1495) % len(episodes))
 
 	def syncEpisodes(self):
-		if not self.show_progress and self.sync_on_update and self.notify:
+		if not self.show_progress and self.sync_on_update and self.notify and self.notify_during_playback:
 			notification('%s %s' % (utilities.getString(1400), utilities.getString(1406)), utilities.getString(1420)) #Sync started
 		if self.show_progress and not self.run_silent:
 			progress.create("%s %s" % (utilities.getString(1400), utilities.getString(1406)), line1=" ", line2=" ", line3=" ")
@@ -454,7 +455,7 @@ class Sync():
 			traktShowsRemove = self.compareShows(traktShows, xbmcShows)
 			self.traktRemoveEpisodes(traktShowsRemove)
 
-		if not self.show_progress and self.sync_on_update and self.notify:
+		if not self.show_progress and self.sync_on_update and self.notify and self.notify_during_playback:
 			notification('%s %s' % (utilities.getString(1400), utilities.getString(1406)), utilities.getString(1421)) #Sync complete
 
 		if not self.isCanceled() and self.show_progress and not self.run_silent:
@@ -706,7 +707,7 @@ class Sync():
 		self.updateProgress(80, line2=utilities.getString(1473) % len(movies))
 
 	def syncMovies(self):
-		if not self.show_progress and self.sync_on_update and self.notify:
+		if not self.show_progress and self.sync_on_update and self.notify and self.notify_during_playback:
 			notification('%s %s' % (utilities.getString(1400), utilities.getString(1402)), utilities.getString(1420)) #Sync started
 		if self.show_progress and not self.run_silent:
 			progress.create("%s %s" % (utilities.getString(1400), utilities.getString(1402)), line1=" ", line2=" ", line3=" ")
@@ -745,7 +746,7 @@ class Sync():
 			self.updateProgress(100, line1=utilities.getString(1431), line2=" ", line3=" ")
 			progress.close()
 
-		if not self.show_progress and self.sync_on_update and self.notify:
+		if not self.show_progress and self.sync_on_update and self.notify and self.notify_during_playback:
 			notification('%s %s' % (utilities.getString(1400), utilities.getString(1402)), utilities.getString(1421)) #Sync complete
 		
 		Debug("[Movies Sync] Movies on trakt.tv (%d), movies in XBMC (%d)." % (len(traktMovies), self.countMovies(xbmcMovies)))


### PR DESCRIPTION
Add setting to show or hide automatic sync notifications during playback.

This should allow one to hide the popup notifications that occur during an automatic sync (library update) when you're playing back a video.

Implements #147
