### PR TITLE
Ability to specify which library is updated in manual sync.

### DIFF
--- a/script.py
+++ b/script.py
@@ -98,6 +98,9 @@ def Main():
 		data['silent'] = False
 		if 'silent' in args:
 			data['silent'] = (args['silent'].lower() == 'true')
+		data['library'] = "all"
+		if 'library' in args and args['library'] in ['episodes', 'movies']:
+			data['library'] = args['library']
 
 	elif args['action'] == 'loadsettings':
 		data = {'action': 'loadsettings', 'force': True}

--- a/service.py
+++ b/service.py
@@ -74,7 +74,7 @@ class traktService:
 		elif action == 'manualSync':
 			if not self.syncThread.isAlive():
 				utilities.Debug("Performing a manual sync.")
-				self.doSync(manual=True, silent=data['silent'])
+				self.doSync(manual=True, silent=data['silent'], library=data['library'])
 			else:
 				utilities.Debug("There already is a sync in progress.")
 		elif action == 'updatetags':
@@ -347,22 +347,23 @@ class traktService:
 						if markedNotification:
 							utilities.notification(utilities.getString(1550), utilities.getString(1552) % (len(params['episodes']), s))
 
-	def doSync(self, manual=False, silent=False):
-		self.syncThread = syncThread(manual, silent)
+	def doSync(self, manual=False, silent=False, library="all"):
+		self.syncThread = syncThread(manual, silent, library)
 		self.syncThread.start()
 
 class syncThread(threading.Thread):
 
 	_isManual = False
 
-	def __init__(self, isManual=False, runSilent=False):
+	def __init__(self, isManual=False, runSilent=False, library="all"):
 		threading.Thread.__init__(self)
 		self.name = "trakt-sync"
 		self._isManual = isManual
 		self._runSilent = runSilent
+		self._library = library
 
 	def run(self):
-		sync = Sync(show_progress=self._isManual, run_silent=self._runSilent, api=globals.traktapi)
+		sync = Sync(show_progress=self._isManual, run_silent=self._runSilent, library=self._library, api=globals.traktapi)
 		sync.sync()
 		
 		if utilities.getSettingAsBool('tagging_enable') and utilities.getSettingAsBool('tagging_tag_after_sync'):

--- a/sync.py
+++ b/sync.py
@@ -10,10 +10,11 @@ progress = xbmcgui.DialogProgress()
 
 class Sync():
 
-	def __init__(self, show_progress=False, run_silent=False, api=None):
+	def __init__(self, show_progress=False, run_silent=False, library="all", api=None):
 		self.traktapi = api
 		self.show_progress = show_progress
 		self.run_silent = run_silent
+		self.library = library
 		if self.show_progress and self.run_silent:
 			Debug("[Sync] Sync is being run silently.")
 		self.sync_on_update = utilities.getSettingAsBool('sync_on_update')
@@ -764,12 +765,18 @@ class Sync():
 		Debug("[Sync] Starting synchronization with trakt.tv")
 
 		if self.syncCheck('movies'):
-			self.syncMovies()
+			if self.library in ["all", "movies"]:
+				self.syncMovies()
+			else:
+				Debug("[Sync] Movie sync is being skipped for this manual sync.")
 		else:
 			Debug("[Sync] Movie sync is disabled, skipping.")
 
 		if self.syncCheck('episodes'):
-			self.syncEpisodes()
+			if self.library in ["all", "episodes"]:
+				self.syncEpisodes()
+			else:
+				Debug("[Sync] Episode sync is being skipped for this manual sync.")
 		else:
 			Debug("[Sync] Episode sync is disabled, skipping.")
 


### PR DESCRIPTION
## Features

Add ability to specify which library gets updated in manual sync with a new variable, library.

Default action for manual sync is all.

Usage:

```
RunScript(script.trakt,action=sync[,silent=True][,library=[all|episodes|movies]])
```

Example:

```
RunScript(script.trakt,action=sync,library=episodes)
```

The above example will trigger a sync only for tv shows.
## Changes
- Add ability to specify which library gets updated in manual sync with a new variable, library. This still checks if episode/movie sync is enabled or disabled.
- Usage: RunScript(script.trakt,action=sync[,silent=True][,library=[all|episodes|movies]])
- The variable is optional, and if omitted defaults to all.
