### PR TITLE
Force argument should have been optional.

### DIFF
--- a/traktapi.py
+++ b/traktapi.py
@@ -319,7 +319,7 @@ class traktAPI(object):
 
 	# url: http://api.trakt.tv/account/settings/<apikey>
 	# returns: all settings for authenticated user
-	def getAccountSettings(self, force):
+	def getAccountSettings(self, force=False):
 		_interval = (60 * 60 * 24 * 7) - (60 * 60) # one week less one hour
 
 		_next = getSettingAsInt('trakt_settings_last') + _interval


### PR DESCRIPTION
Seems this was overlooked, force argument in getAccountSettings should have been optional.

Should fix an error a user on XBMC forums was getting.
