### PR TITLE
Fix for when the lastplayed value is empty in XBMC movie json data

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -551,7 +551,8 @@ class Sync():
 		for movie in movies:
 			if self.checkExclusion(movie['file']):
 				continue
-			movie['last_played'] = utilities.sqlDateToUnixDate(movie['lastplayed'])
+			if movie['lastplayed']:
+				movie['last_played'] = utilities.sqlDateToUnixDate(movie['lastplayed'])
 			movie['plays'] = movie.pop('playcount')
 			movie['in_collection'] = True
 			movie['imdb_id'] = ""

--- a/utilities.py
+++ b/utilities.py
@@ -117,7 +117,11 @@ def sqlDateToUnixDate(date):
 	if not date:
 		return 0
 	t = time.strptime(date, "%Y-%m-%d %H:%M:%S")
-	return int(time.mktime(t))
+	try:
+		utime = int(time.mktime(t))
+	except OverflowError:
+		utime = None
+	return utime
 
 def chunks(l, n):
 	return [l[i:i+n] for i in range(0, len(l), n)]


### PR DESCRIPTION
Needs to be quickly tested, but should work.  Seen this crop up a couple times on the forums, so here is a fix for this.
## Changes

Check for last played value when loading movies from xbmc, only convert it if its present.
Add a try/catch when converting an sql date to a unix time stamp.
