### PR TITLE
Split apart movie operations during sync

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -106,11 +106,13 @@
 	<!-- Sync Movies - add to trakt -->
 	<string id="1467">trakt.tv movie collection is up to date, no movies to add.</string>
 	<string id="1426">movie(s) will be added to trakt collection</string>
+	<string id="1477">Adding movies to trakt.tv collection</string>
 	<string id="1468">%i movie(s) were added to your trakt.tv collection.</string>
 
 	<!-- Sync Movies - update trakt -->
 	<string id="1469">trakt.tv movie playcount is up to date.</string>
 	<string id="1428">movie(s) playcount will be updated on trakt</string>
+	<string id="1478">Updating movie play counts on trakt.tv</string>
 	<string id="1470">Play counts updated for %i movie(s) on trakt.tv</string>
 	
 	<!-- Sync Movies - update xbmc -->
@@ -122,6 +124,7 @@
 	<!-- Sync Movies - clean trakt -->
 	<string id="1474">trakt.tv movie collection is up to date.</string>
 	<string id="1444">movie(s) will be removed from trakt collection</string>
+	<string id="1476">Removing movies from trakt.tv collection</string>
 	<string id="1475">%i movie(s) were removed from your trakt.tv collection</string>
 
 	<!-- Sync Movies - complete -->

--- a/sync.py
+++ b/sync.py
@@ -640,11 +640,21 @@ class Sync():
 
 		self.updateProgress(20, line2="%i %s" % (len(movies), utilities.getString(1426)))
 
-		params = {'movies': [self.sanitizeMovieData(movie) for movie in movies]}
-		if self.simulate:
-			Debug("[Movies Sync] %s" % str(params))
-		else:
-			self.traktapi.addMovie(params)
+		chunked_movies = utilities.chunks([self.sanitizeMovieData(movie) for movie in movies], 50)
+		i = 0
+		x = float(len(chunked_movies))
+		for chunk in chunked_movies:
+			if self.isCanceled():
+				return
+			params = {'movies': chunk}
+			if self.simulate:
+				Debug("[Movies Sync] %s" % str(params))
+			else:
+				self.traktapi.addMovie(params)
+
+			i = i + 1
+			y = ((i / x) * 20) + 20
+			self.updateProgress(int(y), line2=utilities.getString(1477))
 
 		self.updateProgress(40, line2=utilities.getString(1468) % len(movies))
 
@@ -660,11 +670,21 @@ class Sync():
 
 		self.updateProgress(80, line2="%i %s" % (len(movies), utilities.getString(1444)))
 		
-		params = {'movies': [self.sanitizeMovieData(movie) for movie in movies]}
-		if self.simulate:
-			Debug("[Movies Sync] %s" % str(params))
-		else:
-			self.traktapi.removeMovie(params)
+		chunked_movies = utilities.chunks([self.sanitizeMovieData(movie) for movie in movies], 50)
+		i = 0
+		x = float(len(chunked_movies))
+		for chunk in chunked_movies:
+			if self.isCanceled():
+				return
+			params = {'movies': chunk}
+			if self.simulate:
+				Debug("[Movies Sync] %s" % str(params))
+			else:
+				self.traktapi.removeMovie(params)
+
+			i = i + 1
+			y = ((i / x) * 20) + 80
+			self.updateProgress(int(y), line2=utilities.getString(1476))
 
 		self.updateProgress(98, line2=utilities.getString(1475) % len(movies))
 
@@ -681,11 +701,21 @@ class Sync():
 		self.updateProgress(40, line2="%i %s" % (len(movies), utilities.getString(1428)))
 
 		# Send request to update playcounts on trakt.tv
-		params = {'movies': [self.sanitizeMovieData(movie) for movie in movies]}
-		if self.simulate:
-			Debug("[Movies Sync] %s" % str(params))
-		else:
-			self.traktapi.updateSeenMovie(params)
+		chunked_movies = utilities.chunks([self.sanitizeMovieData(movie) for movie in movies], 50)
+		i = 0
+		x = float(len(chunked_movies))
+		for chunk in chunked_movies:
+			if self.isCanceled():
+				return
+			params = {'movies': chunk}
+			if self.simulate:
+				Debug("[Movies Sync] %s" % str(params))
+			else:
+				self.traktapi.updateSeenMovie(params)
+
+			i = i + 1
+			y = ((i / x) * 20) + 40
+			self.updateProgress(int(y), line2=utilities.getString(1478))
 
 		self.updateProgress(60, line2=utilities.getString(1470) % len(movies))
 


### PR DESCRIPTION
Movie operations during sync have been split into 50 item chunks now, seems initial syncs or large syncs were causing 500 Internal Errors at trakt.tv, this must be a recent change, as it use to be fine.

Split apart the adding of movies to trakt
Split apart removing of movies to trakt
Split apart updating movies to trakt
Seems recently it has not been working (500 internal error) if there is a large amount (400+ in adding, 120+ in removing)
