### PR TITLE
Logging fixes

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -68,8 +68,6 @@
 		<setting id="tagging_notifications" type="bool" label="1608" default="true"/>
 	</category>
 	<category label="1700"><!-- Debug -->
-		<setting label="1720" type="lsep"/>
-		<setting id="debug" type="bool" label="1701" default="true"/>
 		<setting type="sep"/>
 		<setting label="1721" type="lsep"/>
 		<setting id="simulate_scrobbling" type="bool" label="1702" default="false"/>

--- a/traktapi.py
+++ b/traktapi.py
@@ -203,7 +203,12 @@ class traktAPI(object):
 				if hideResponse:
 					Debug("[traktAPI] traktRequest(): (%i) JSON response recieved, response not logged" % i)
 				else:
-					Debug("[traktAPI] traktRequest(): (%i) JSON response: '%s'" % (i, str(data)))
+					text = str(data)
+					if len(text) > 1000:
+						text = text[:1000]
+						Debug("[traktAPI] traktRequest(): (%i) JSON response (snippet): '%s'" % (i, text))
+					else:
+						Debug("[traktAPI] traktRequest(): (%i) JSON response: '%s'" % (i, text))
 			except ValueError:
 				# malformed json response
 				Debug("[traktAPI] traktRequest(): (%i) Bad JSON response: '%s'" % (i, raw))

--- a/utilities.py
+++ b/utilities.py
@@ -35,12 +35,9 @@ REGEX_EXPRESSIONS = [ '[Ss]([0-9]+)[][._-]*[Ee]([0-9]+)([^\\\\/]*)$',
                       '[\\\\/\\._ \\[\\(-]([0-9]+)x([0-9]+)([^\\\\/]*)$'
                      ]
 
-def Debug(msg, force = False):
-	if(getSettingAsBool('debug') or force):
-		try:
-			print "[trakt] " + msg
-		except UnicodeEncodeError:
-			print "[trakt] " + msg.encode('utf-8', 'ignore')
+def Debug(msg, error=False):
+	level = xbmc.LOGERROR if error else xbmc.LOGDEBUG
+	xbmc.log("[trakt] %s" % msg, level=level)
 
 def notification(header, message, time=5000, icon=__addon__.getAddonInfo('icon')):
 	xbmc.executebuiltin("XBMC.Notification(%s,%s,%i,%s)" % (header, message, time, icon))


### PR DESCRIPTION
1. Print defaults to the 'notice' level. Debug logging should be done with `xbmc.log` respecting the system log level setting.
2. Some of those responses can be _extremely_ large. I highly doubt anybody needs to see _everything_ so I changed to log the beginning.
