### PR TITLE
Fix: Include obfuscated API keys in distribution zip

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -17,7 +17,11 @@ jobs:
         env:
           TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           TRAKT_CLIENT_SECRET: ${{ secrets.TRAKT_CLIENT_SECRET }}
-        run: python3 scripts/inject_keys.py
+        run: |
+          python3 scripts/inject_keys.py
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "Inject obfuscated keys for build [skip ci]"
       - name: Generate distribution zip and submit to official kodi repository
         id: kodi-addon-submitter
         uses: xbmc/action-kodi-addon-submitter@v1.3


### PR DESCRIPTION
# Fix for action-kodi-addon-submitter

This PR fixes an issue where the obfuscated Trakt API keys were missing from the
distribution zip.

The `xbmc/action-kodi-addon-submitter` action uses `git archive HEAD` under the
hood to generate the addon's zip file. Because `git archive` only packages files
that are committed to the repository, it was completely ignoring the uncommitted
changes made by our `scripts/inject_keys.py` step during the build.

### Changes

- **Temporarily commit injected keys**: Updated `.github/workflows/submit.yml`
  to run a local `git commit -am "Inject obfuscated keys for build [skip ci]"`
  immediately after running the injection script.

This ensures the modified `traktapi.py` with the obfuscated keys is included in
the `HEAD` archive and successfully packaged into the release ZIP. This commit
only exists on the GitHub Actions runner and is never pushed back to the
repository.
