### PR TITLE
Add unit tests for utilities and obfuscation

### DIFF
--- a/tests/test_obfuscation.py
+++ b/tests/test_obfuscation.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from resources.lib import obfuscation
+
+def test_obfuscate():
+    assert obfuscation.obfuscate("test") == [54, 39, 49, 54]
+
+def test_deobfuscate():
+    assert obfuscation.deobfuscate([54, 39, 49, 54]) == "test"
+
+def test_obfuscate_empty():
+    assert obfuscation.obfuscate("") == []
+
+def test_deobfuscate_empty():
+    assert obfuscation.deobfuscate("") == ""
+    assert obfuscation.deobfuscate(None) == ""
+    assert obfuscation.deobfuscate("not a list") == ""
+
+def test_roundtrip():
+    original = "Hello, World!"
+    assert obfuscation.deobfuscate(obfuscation.obfuscate(original)) == original

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -567,3 +567,68 @@ def test_countEpisodes2():
     )
 
     assert utilities.countEpisodes(data1) == 5
+
+
+def test_to_sec():
+    assert utilities._to_sec("1:01:01") == 3661
+    assert utilities._to_sec("01:01") == 61
+    assert utilities._to_sec("01") == 1
+
+
+def test_fuzzyMatch():
+    assert utilities._fuzzyMatch("The Dark Knight", "The Dark Knight")
+    assert utilities._fuzzyMatch("The Dark Knight", "Dark Knight")
+    assert not utilities._fuzzyMatch("The Dark Knight", "The Joker")
+
+
+def test_sanitizeShows():
+    shows = {
+        "shows": [
+            {
+                "title": "Batman",
+                "seasons": [
+                    {
+                        "number": 1,
+                        "episodes": [
+                            {
+                                "number": 1,
+                                "collected": True,
+                                "watched": True,
+                                "season": 1,
+                                "plays": 1,
+                                "ids": {"trakt": 1, "episodeid": 1},
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    utilities.sanitizeShows(shows)
+    episode = shows["shows"][0]["seasons"][0]["episodes"][0]
+    assert "collected" not in episode
+    assert "watched" not in episode
+    assert "season" not in episode
+    assert "plays" not in episode
+    assert "episodeid" not in episode["ids"]
+
+
+def test_convertDateTimeToUTC():
+    # 2023-10-27 10:00:00 UTC
+    utc_str = utilities.convertDateTimeToUTC("2023-10-27 10:00:00")
+    assert "2023-10-27" in utc_str
+
+
+def test_convertUtcToDateTime():
+    # 2023-10-27T10:00:00.000Z
+    local_str = utilities.convertUtcToDateTime("2023-10-27T10:00:00.000Z")
+    assert "2023-10-27" in local_str
+
+
+def test_createError():
+    try:
+        raise ValueError("test error")
+    except ValueError as e:
+        error_msg = utilities.createError(e)
+        assert "ValueError" in error_msg
+        assert "test error" in error_msg


### PR DESCRIPTION
I have added several unit tests to improve the test coverage of the repository, specifically focusing on the `utilities` and `obfuscation` modules in `resources/lib/`. 

New tests include:
- `tests/test_obfuscation.py`: Tests for string obfuscation and deobfuscation, including edge cases and round-trip verification.
- `tests/test_utilities.py`:
    - `test_to_sec`: Verifies time duration string to seconds conversion.
    - `test_fuzzyMatch`: Verifies string similarity matching.
    - `test_sanitizeShows`: Verifies that sensitive/internal metadata is correctly stripped from show data.
    - `test_convertDateTimeToUTC` and `test_convertUtcToDateTime`: Basic verification of datetime string conversions.
    - `test_createError`: Verifies the formatting of exception error reports.

All tests were verified to pass using `pytest`.

---
*PR created automatically by Jules for task [11482853510036946467](https://jules.google.com/task/11482853510036946467) started by @razzeee*