### PR TITLE
Fix functional bugs in utilities and scrobbler

### DIFF
--- a/resources/lib/scrobbler.py
+++ b/resources/lib/scrobbler.py
@@ -240,7 +240,7 @@ class Scrobbler:
                 else:
                     self.videoDuration = xbmc.Player().getTotalTime()
             except Exception as e:
-                logger.debug("Suddenly stopped watching item: %s" % e.message)
+                logger.debug("Suddenly stopped watching item: %s" % str(e))
                 self.curVideo = None
                 return
 
@@ -409,9 +409,11 @@ class Scrobbler:
 
     def __preFetchUserRatings(self, result: Dict) -> None:
         if result:
-            if utilities.isMovie(
-                self.curVideo["type"]
-            ) and kodiUtilities.getSettingAsBool("rate_movie"):
+            if (
+                utilities.isMovie(self.curVideo["type"])
+                and kodiUtilities.getSettingAsBool("rate_movie")
+                and "movie" in result
+            ):
                 # pre-get summary information, for faster rating dialog.
                 logger.debug(
                     "Movie rating is enabled, pre-fetching summary information."
@@ -422,9 +424,12 @@ class Scrobbler:
                         result["movie"]["ids"]["trakt"], "trakt"
                     )
                 }
-            elif utilities.isEpisode(
-                self.curVideo["type"]
-            ) and kodiUtilities.getSettingAsBool("rate_episode"):
+            elif (
+                utilities.isEpisode(self.curVideo["type"])
+                and kodiUtilities.getSettingAsBool("rate_episode")
+                and "episode" in result
+                and "show" in result
+            ):
                 # pre-get summary information, for faster rating dialog.
                 logger.debug(
                     "Episode rating is enabled, pre-fetching summary information."

--- a/resources/lib/utilities.py
+++ b/resources/lib/utilities.py
@@ -204,7 +204,7 @@ def findSeasonMatchInList(id: str, seasonNumber: int, listToMatch: Dict, idType:
 
 
 def findEpisodeMatchInList(id: str, seasonNumber: int, episodeNumber: int, list_data: Dict, idType: str) -> Dict:
-    season = findSeasonMatchInList(id, seasonNumber, list, idType)
+    season = findSeasonMatchInList(id, seasonNumber, list_data, idType)
     if season:
         for episode in season["episodes"]:
             if episode["number"] == episodeNumber:

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -632,3 +632,26 @@ def test_createError():
         error_msg = utilities.createError(e)
         assert "ValueError" in error_msg
         assert "test error" in error_msg
+
+
+def test_findEpisodeMatchInList():
+    # Mocking a structure that would be returned by Trakt API
+    class MockItem:
+        def __init__(self, data, keys):
+            self.data = data
+            self.keys = keys
+
+        def to_dict(self):
+            return self.data
+
+    episode_data = {"number": 1, "title": "Winter Is Coming"}
+    season_data = {"number": 1, "episodes": [episode_data]}
+    show_data = {"title": "Game of Thrones", "seasons": [season_data]}
+
+    mock_show = MockItem(show_data, [("tvdb", "121361")])
+    list_data = {"121361": mock_show}
+
+    # This should trigger the bug where 'list' is passed instead of 'list_data'
+    # and fail with AttributeError: type object 'list' has no attribute 'items'
+    result = utilities.findEpisodeMatchInList("121361", 1, 1, list_data, "tvdb")
+    assert result == episode_data


### PR DESCRIPTION
This change fixes several functional bugs and improves code robustness:
1. In `resources/lib/utilities.py`, the `findEpisodeMatchInList` function was incorrectly passing the built-in `list` type instead of the `list_data` parameter to a helper function.
2. In `resources/lib/scrobbler.py`, a reference to `e.message` (removed in Python 3) was replaced with `str(e)`.
3. In `resources/lib/scrobbler.py`, the `__preFetchUserRatings` method now checks for the existence of expected keys in the API response before accessing them.
4. A new test case was added to `tests/test_utilities.py` to verify the fix and prevent regression of the `findEpisodeMatchInList` bug.

---
*PR created automatically by Jules for task [12676173689244080702](https://jules.google.com/task/12676173689244080702) started by @razzeee*