### PR TITLE
Request extended=progress and paginate the watched/collected getters

### DIFF
--- a/resources/lib/traktapi.py
+++ b/resources/lib/traktapi.py
@@ -404,6 +404,7 @@ class traktAPI(object):
         authorized: bool = False,
         timeout: int = 90,
         limit: int = 100,
+        params: Optional[Dict] = None,
     ) -> List:
         if not self.client:
             return []
@@ -412,7 +413,10 @@ class traktAPI(object):
         page = 1
         page_count = 1
         while page <= page_count:
-            page_path = self.client.build_path(path, {"page": page, "limit": limit})
+            query = {"page": page, "limit": limit}
+            if params:
+                query.update(params)
+            page_path = self.client.build_path(path, query)
             response = self._get(
                 page_path,
                 authorized=authorized,
@@ -595,8 +599,8 @@ class traktAPI(object):
         )
 
     def getShowsCollected(self, shows: Dict) -> Dict:
-        for item in (
-            self._get("/sync/collection/shows", authorized=True, timeout=90) or []
+        for item in self._get_all_pages(
+            "/sync/collection/shows", authorized=True, timeout=90
         ):
             self._merge_show(shows, item, ("collected_at",))
         return shows
@@ -609,15 +613,23 @@ class traktAPI(object):
         return movies
 
     def getShowsWatched(self, shows: Dict) -> Dict:
-        for item in self._get("/sync/watched/shows", authorized=True, timeout=90) or []:
+        # extended=progress is required for the season/episode breakdown; without
+        # it Trakt returns show-level plays only and episode watched-state can't
+        # be synced. All sync endpoints are also paginated, so page through them.
+        for item in self._get_all_pages(
+            "/sync/watched/shows",
+            authorized=True,
+            timeout=90,
+            params={"extended": "progress"},
+        ):
             self._merge_show(
                 shows, item, ("plays", "last_watched_at", "last_updated_at", "reset_at")
             )
         return shows
 
     def getMoviesWatched(self, movies: Dict) -> Dict:
-        for item in (
-            self._get("/sync/watched/movies", authorized=True, timeout=90) or []
+        for item in self._get_all_pages(
+            "/sync/watched/movies", authorized=True, timeout=90
         ):
             self._merge_object(
                 movies, item, "movie", ("plays", "last_watched_at", "last_updated_at")

--- a/tests/test_traktapi.py
+++ b/tests/test_traktapi.py
@@ -217,6 +217,23 @@ def test_get_all_pages_follows_pagination_headers():
     )
 
 
+def test_get_all_pages_merges_extra_params_into_query():
+    api = traktAPI.__new__(traktAPI)
+    api.client = TraktClient("id", "secret", "ua")
+    api._get = mock.Mock(return_value=([{"title": "One"}], {}))
+
+    api._get_all_pages(
+        "/sync/watched/shows", authorized=True, params={"extended": "progress"}
+    )
+
+    api._get.assert_called_once_with(
+        "/sync/watched/shows?page=1&limit=100&extended=progress",
+        authorized=True,
+        timeout=90,
+        include_headers=True,
+    )
+
+
 def test_get_all_ratings_fetches_current_rating_bucket_endpoints():
     api = traktAPI.__new__(traktAPI)
     api._get_all_pages = mock.Mock(return_value=[])
@@ -267,6 +284,55 @@ def test_episode_playback_progress_uses_pagination():
     )
     episode = result[0].to_dict()["seasons"][0]["episodes"][0]
     assert episode["progress"] == 50
+
+
+def test_get_shows_watched_requests_progress_and_paginates():
+    api = traktAPI.__new__(traktAPI)
+    api._get_all_pages = mock.Mock(
+        return_value=[
+            {
+                "plays": 3,
+                "last_watched_at": "2026-01-01T00:00:00.000Z",
+                "show": {"title": "Show", "ids": {"trakt": 1}},
+                "seasons": [{"number": 1, "episodes": [{"number": 1, "plays": 1}]}],
+            }
+        ]
+    )
+
+    result = api.getShowsWatched({})
+
+    # extended=progress is what restores the season/episode breakdown (Trakt 2026
+    # API change); without it episode watched-state can't be synced.
+    api._get_all_pages.assert_called_once_with(
+        "/sync/watched/shows",
+        authorized=True,
+        timeout=90,
+        params={"extended": "progress"},
+    )
+    episode = result[1].to_dict()["seasons"][0]["episodes"][0]
+    assert episode["plays"] == 1
+
+
+def test_get_shows_collected_paginates():
+    api = traktAPI.__new__(traktAPI)
+    api._get_all_pages = mock.Mock(return_value=[])
+
+    api.getShowsCollected({})
+
+    api._get_all_pages.assert_called_once_with(
+        "/sync/collection/shows", authorized=True, timeout=90
+    )
+
+
+def test_get_movies_watched_paginates():
+    api = traktAPI.__new__(traktAPI)
+    api._get_all_pages = mock.Mock(return_value=[])
+
+    api.getMoviesWatched({})
+
+    api._get_all_pages.assert_called_once_with(
+        "/sync/watched/movies", authorized=True, timeout=90
+    )
 
 
 def test_client_retries_once_after_rate_limit_retry_after():


### PR DESCRIPTION
**What**

Trakt's 2026 API change (enforced after 2026-06-30) broke the Trakt→Kodi watched-status pull: `/sync/watched/shows` no longer returns the season/episode breakdown unless `extended=progress` is sent, and all `/sync` endpoints are now force-paginated (100/page default).

The new REST client added `_get_all_pages`, but `getShowsWatched` calls a bare `_get` with no `extended=progress` (→ episode watched-state can't sync, #713), and `getShowsWatched`/`getShowsCollected`/`getMoviesWatched` don't page (→ silently truncated to the first 100 items).

**Change**

- `getShowsWatched`: send `extended=progress` and page via `_get_all_pages`.
- `getShowsCollected`, `getMoviesWatched`: route through `_get_all_pages`.
- `_get_all_pages`: accept optional extra query params (merged per page).
- Tests for the above.

**Verification** (live account, `/sync/watched/shows` page 1)

| `extended=progress` | shows | w/ seasons | episodes | page-count |
|---|---|---|---|---|
| off | 100 | 0 | 0 | 5 |
| on | 100 | 100 | 1235 | 5 |

`extended=progress` restores the breakdown; `page-count=5` confirms pagination is required.

**Note:** rebased onto the REST-client rewrite (supersedes the earlier version of this PR, which targeted the pre-rewrite `traktapi.py`). `Refs #713`. Heads-up: on current `main`, a sync still can't complete end-to-end due to a separate object-contract regression (unrelated to pagination) — reported in #715. This PR fixes the pagination/`extended` half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
