### PR TITLE
fix: Fix syncing of movie watched state from new trakt api (Issue #715).

### DIFF
--- a/resources/lib/traktapi.py
+++ b/resources/lib/traktapi.py
@@ -460,18 +460,34 @@ class traktAPI(object):
         for key in metadata_keys:
             if key in item:
                 media[key] = item[key]
-        # Normalize watched status for callers expecting it.
-        if "plays" in media and "watched" not in media:
-            media["watched"] = 1 if media["plays"] > 0 else 0
         ids = media.get("ids") or {}
         key = ids.get("trakt") or media.get("title") or len(store)
         existing = store.get(key)
         if existing:
             merged = existing.to_dict()
             merged.update(media)
-            store[key] = TraktObject(merged)
         else:
-            store[key] = TraktObject(media)
+            merged = media
+        if media_key == "movie":
+            self._normalize_video(merged, media)
+        store[key] = TraktObject(merged)
+
+    def _normalize_video(self, merged: Dict, incoming: Dict) -> None:
+        if "plays" in incoming:
+            merged["watched"] = 1 if incoming["plays"] > 0 else 0
+        elif "watched" not in merged:
+            merged["watched"] = 1 if merged.get("plays", 0) > 0 else 0
+        if "plays" not in merged:
+            merged["plays"] = 0
+        if "collected_at" in incoming:
+            merged["collected"] = 1
+        elif "collected" not in merged:
+            merged["collected"] = 1 if merged.get("collected_at") else 0
+        merged.setdefault("in_watchlist", 0)
+        merged.setdefault("progress", None)
+        merged.setdefault("last_watched_at", None)
+        merged.setdefault("collected_at", None)
+        merged.setdefault("paused_at", None)
 
     def _merge_show(
         self, store: Dict, item: Dict, metadata_keys: Iterable[str]
@@ -526,6 +542,7 @@ class traktAPI(object):
             number = episode.get("number")
             merged = episodes.get(number, {"number": number})
             merged.update(episode)
+            self._normalize_video(merged, episode)
             episodes[number] = merged
         return list(episodes.values())
 

--- a/resources/lib/traktapi.py
+++ b/resources/lib/traktapi.py
@@ -460,6 +460,9 @@ class traktAPI(object):
         for key in metadata_keys:
             if key in item:
                 media[key] = item[key]
+        # Normalize watched status for callers expecting it.
+        if "plays" in media and "watched" not in media:
+            media["watched"] = 1 if media["plays"] > 0 else 0
         ids = media.get("ids") or {}
         key = ids.get("trakt") or media.get("title") or len(store)
         existing = store.get(key)

--- a/tests/test_traktapi.py
+++ b/tests/test_traktapi.py
@@ -19,6 +19,7 @@ xbmcaddon_mock = mock.Mock()
 xbmcaddon_mock.Addon.return_value.getAddonInfo.return_value = "3.8.2"
 sys.modules["xbmcaddon"] = xbmcaddon_mock
 
+from resources.lib import utilities  # noqa: E402
 from resources.lib.traktapi import TraktClient, TraktObject, TraktSeason, traktAPI  # noqa: E402
 
 
@@ -68,6 +69,83 @@ def test_merge_movie_sync_payloads_preserves_object_shape():
     assert movie.to_dict()["plays"] == 2
 
 
+def test_merge_movie_collection_payload_preserves_legacy_defaults():
+    api = traktAPI.__new__(traktAPI)
+    store = {}
+
+    api._merge_object(
+        store,
+        {
+            "collected_at": "2024-01-01",
+            "movie": {"title": "Movie", "year": 2024, "ids": {"trakt": 1}},
+        },
+        "movie",
+        ("collected_at",),
+    )
+
+    movie = store[1].to_dict()
+    assert movie["collected"] == 1
+    assert movie["watched"] == 0
+    assert movie["plays"] == 0
+    assert movie["in_watchlist"] == 0
+    assert movie["progress"] is None
+    assert movie["last_watched_at"] is None
+    assert movie["paused_at"] is None
+
+
+def test_merge_movie_watched_payload_preserves_legacy_defaults():
+    api = traktAPI.__new__(traktAPI)
+    store = {}
+
+    api._merge_object(
+        store,
+        {"plays": 2, "movie": {"title": "Movie", "ids": {"trakt": 1}}},
+        "movie",
+        ("plays",),
+    )
+
+    movie = store[1].to_dict()
+    assert movie["watched"] == 1
+    assert movie["collected"] == 0
+    assert movie["plays"] == 2
+    assert movie["in_watchlist"] == 0
+    assert movie["progress"] is None
+    assert movie["collected_at"] is None
+    assert movie["paused_at"] is None
+
+
+def test_collected_only_trakt_movie_does_not_break_watched_compare():
+    api = traktAPI.__new__(traktAPI)
+    store = {}
+
+    api._merge_object(
+        store,
+        {
+            "collected_at": "2024-01-01",
+            "movie": {"title": "Movie", "year": 2024, "ids": {"trakt": 1}},
+        },
+        "movie",
+        ("collected_at",),
+    )
+
+    kodi_movies = [
+        {
+            "title": "Movie",
+            "year": 2024,
+            "ids": {"trakt": 1},
+            "watched": 1,
+            "plays": 1,
+            "movieid": 10,
+        }
+    ]
+    trakt_movies = [movie.to_dict() for movie in store.values()]
+
+    assert (
+        utilities.compareMovies(kodi_movies, trakt_movies, True, watched=True)
+        == kodi_movies
+    )
+
+
 def test_merge_show_payloads_merges_nested_episodes():
     api = traktAPI.__new__(traktAPI)
     store = {}
@@ -93,6 +171,89 @@ def test_merge_show_payloads_merges_nested_episodes():
 
     episode = store[1].to_dict()["seasons"][0]["episodes"][0]
     assert episode["collected_at"] == "now"
+    assert episode["plays"] == 3
+
+
+def test_merge_show_collection_payload_preserves_legacy_episode_defaults():
+    api = traktAPI.__new__(traktAPI)
+    store = {}
+
+    api._merge_show(
+        store,
+        {
+            "show": {"title": "Show", "ids": {"trakt": 1}},
+            "seasons": [
+                {
+                    "number": 1,
+                    "episodes": [{"number": 2, "collected_at": "now"}],
+                }
+            ],
+        },
+        ("collected_at",),
+    )
+
+    episode = store[1].to_dict()["seasons"][0]["episodes"][0]
+    assert episode["collected"] == 1
+    assert episode["watched"] == 0
+    assert episode["plays"] == 0
+    assert episode["in_watchlist"] == 0
+    assert episode["progress"] is None
+    assert episode["last_watched_at"] is None
+    assert episode["paused_at"] is None
+
+
+def test_merge_show_watched_payload_preserves_legacy_episode_defaults():
+    api = traktAPI.__new__(traktAPI)
+    store = {}
+
+    api._merge_show(
+        store,
+        {
+            "show": {"title": "Show", "ids": {"trakt": 1}},
+            "seasons": [{"number": 1, "episodes": [{"number": 2, "plays": 3}]}],
+        },
+        ("plays",),
+    )
+
+    episode = store[1].to_dict()["seasons"][0]["episodes"][0]
+    assert episode["watched"] == 1
+    assert episode["collected"] == 0
+    assert episode["plays"] == 3
+    assert episode["in_watchlist"] == 0
+    assert episode["progress"] is None
+    assert episode["collected_at"] is None
+    assert episode["paused_at"] is None
+
+
+def test_merge_show_preserves_episode_flags_across_collection_and_watched_payloads():
+    api = traktAPI.__new__(traktAPI)
+    store = {}
+
+    api._merge_show(
+        store,
+        {
+            "show": {"title": "Show", "ids": {"trakt": 1}},
+            "seasons": [
+                {
+                    "number": 1,
+                    "episodes": [{"number": 2, "collected_at": "now"}],
+                }
+            ],
+        },
+        ("collected_at",),
+    )
+    api._merge_show(
+        store,
+        {
+            "show": {"title": "Show", "ids": {"trakt": 1}},
+            "seasons": [{"number": 1, "episodes": [{"number": 2, "plays": 3}]}],
+        },
+        ("plays",),
+    )
+
+    episode = store[1].to_dict()["seasons"][0]["episodes"][0]
+    assert episode["collected"] == 1
+    assert episode["watched"] == 1
     assert episode["plays"] == 3
 
 


### PR DESCRIPTION
I am not sure if this is correct, but worked for me. Please code review and test. I can now get trakt to sync watched movie states from trakt to Kodi.

Should fix the issue reported in https://github.com/razzeee/script.trakt/issues/715